### PR TITLE
[Feat] 팀 스페이스 관련 API 구현

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -44,9 +44,9 @@ public class TeamController {
 
     @Operation(summary = "join Team", description = "Use this when you enter the team space")
     @PostMapping("/join")
-    public ResponseEntity<TeamResponse> joinTeam(@RequestBody TeamEnterRequest teamEnterRequest) {
-        TeamResponse teamResponse = teamService.joinTeam(teamEnterRequest);
-        return ResponseEntity.status(201).body(teamResponse);
+    public ResponseEntity<Long> joinTeam(@RequestBody TeamEnterRequest teamEnterRequest) {
+        Long userTeamId = teamService.joinTeam(teamEnterRequest);
+        return ResponseEntity.status(201).body(userTeamId);
     }
 
     @Operation(summary = "leave Team", description = "Use this when you leave the team space")

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -1,0 +1,66 @@
+package CloudProject.A_meet.domain.group.domain.team.controller;
+
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
+import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 팀 관련 Controller
+ * 팀 생성, 조회, 참여/탈퇴/재참여 요청
+ *
+ * @author sungah
+ * */
+
+@RestController
+@RequestMapping("/api/v1/team")
+@Tag(name = "Team", description = "Team API")
+@RequiredArgsConstructor
+@Validated
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @Operation(summary = "Create Team", description = "Use this to create a team")
+    @PostMapping
+    public ResponseEntity<TeamResponse> createMeeting(@RequestBody TeamRequest teamRequest) {
+        TeamResponse teamResponse = teamService.createTeam(teamRequest);
+        return ResponseEntity.status(201).body(teamResponse);
+    }
+
+    @Operation(summary = "Get Team Detail Information", description = "Use this when you enter the team space")
+    @GetMapping
+    public ResponseEntity<TeamResponse> getTeamInfo(@RequestParam("teamId") Long teamId) {
+        TeamResponse teamResponse = teamService.getTeamInfo(teamId);
+        return ResponseEntity.status(200).body(teamResponse);
+    }
+
+    @Operation(summary = "join Team", description = "Use this when you enter the team space")
+    @PostMapping("/join")
+    public ResponseEntity<TeamResponse> joinTeam(@RequestBody TeamEnterRequest teamEnterRequest) {
+        TeamResponse teamResponse = teamService.joinTeam(teamEnterRequest);
+        return ResponseEntity.status(201).body(teamResponse);
+    }
+
+    @Operation(summary = "leave Team", description = "Use this when you leave the team space")
+    @PutMapping("/leave")
+    public ResponseEntity<TeamResponse> leaveTeam(@RequestBody TeamLeaveRequest teamLeaveRequest) {
+        TeamResponse teamResponse = teamService.leaveTeam(teamLeaveRequest);
+        return ResponseEntity.status(200).body(teamResponse);
+    }
+
+    @Operation(summary = "rejoin Team", description = "Use this when you rejoin the team space")
+    @PutMapping("/rejoin")
+    public ResponseEntity<TeamResponse> rejoinTeam(@RequestBody TeamEnterRequest teamEnterRequest) {
+        TeamResponse teamResponse = teamService.rejoinTeam(teamEnterRequest);
+        return ResponseEntity.status(200).body(teamResponse);
+    }
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -51,9 +51,9 @@ public class TeamController {
 
     @Operation(summary = "leave Team", description = "Use this when you leave the team space")
     @PutMapping("/leave")
-    public ResponseEntity<TeamResponse> leaveTeam(@RequestBody TeamLeaveRequest teamLeaveRequest) {
-        TeamResponse teamResponse = teamService.leaveTeam(teamLeaveRequest);
-        return ResponseEntity.status(200).body(teamResponse);
+    public ResponseEntity<?> leaveTeam(@RequestBody TeamLeaveRequest teamLeaveRequest) {
+        teamService.leaveTeam(teamLeaveRequest);
+        return ResponseEntity.status(200).body(null);
     }
 
     @Operation(summary = "rejoin Team", description = "Use this when you rejoin the team space")

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -5,9 +5,11 @@ import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
 import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -45,8 +47,9 @@ public class TeamController {
     @Operation(summary = "join Team", description = "Use this when you enter the team space")
     @PostMapping("/join")
     public ResponseEntity<Long> joinTeam(@RequestBody TeamEnterRequest teamEnterRequest) {
-        Long userTeamId = teamService.joinTeam(teamEnterRequest);
-        return ResponseEntity.status(201).body(userTeamId);
+        JoinResult joinResult = teamService.joinTeam(teamEnterRequest);
+        HttpStatus status = joinResult.wasMember() ? HttpStatus.OK : HttpStatus.CREATED;
+        return ResponseEntity.status(status).body(joinResult.userTeamId());
     }
 
     @Operation(summary = "leave Team", description = "Use this when you leave the team space")

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -30,9 +30,9 @@ public class TeamController {
 
     @Operation(summary = "Create Team", description = "Use this to create a team")
     @PostMapping
-    public ResponseEntity<TeamResponse> createMeeting(@RequestBody TeamRequest teamRequest) {
-        TeamResponse teamResponse = teamService.createTeam(teamRequest);
-        return ResponseEntity.status(201).body(teamResponse);
+    public ResponseEntity<Long> createTeam(@RequestBody TeamRequest teamRequest) {
+        Long teamId = teamService.createTeam(teamRequest);
+        return ResponseEntity.status(201).body(teamId);
     }
 
     @Operation(summary = "Get Team Detail Information", description = "Use this when you enter the team space")

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -56,11 +56,4 @@ public class TeamController {
         return ResponseEntity.status(200).body(null);
     }
 
-    @Operation(summary = "rejoin Team", description = "Use this when you rejoin the team space")
-    @PutMapping("/rejoin")
-    public ResponseEntity<TeamResponse> rejoinTeam(@RequestBody TeamEnterRequest teamEnterRequest) {
-        TeamResponse teamResponse = teamService.rejoinTeam(teamEnterRequest);
-        return ResponseEntity.status(200).body(teamResponse);
-    }
-
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/domain/Team.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/domain/Team.java
@@ -2,15 +2,14 @@ package CloudProject.A_meet.domain.group.domain.team.domain;
 
 import CloudProject.A_meet.global.common.model.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Table(name="teams")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
+@Builder
 @ToString
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -22,6 +21,9 @@ public class Team extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String name;
+
+    @Column(length = 500)
+    private String description;
 
     @Column(nullable = false)
     private String teamPassword;

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamEnterRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamEnterRequest.java
@@ -1,0 +1,18 @@
+package CloudProject.A_meet.domain.group.domain.team.dto;
+
+import lombok.Getter;
+
+/**
+ * Team 생성 시 사용자로부터 입력받는 데이터를 담는 DTO 클래스
+ * - userId: 팀 생성 사용자 ID
+ * - teamName: 팀 이름
+ * - teamPassword: 팀 입장 비밀번호
+ */
+@Getter
+public class TeamEnterRequest {
+
+    private Long userId;
+    private String teamName;
+    private String teamPassword;
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamLeaveRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamLeaveRequest.java
@@ -1,0 +1,16 @@
+package CloudProject.A_meet.domain.group.domain.team.dto;
+
+import lombok.Getter;
+
+/**
+ * Team 탈퇴 시,  탈퇴하려는 사용자 및 팀 정보를 담은 DTO
+ * - userId: 팀 탈퇴 사용자 ID
+ * - teamId: 팀 ID
+ */
+@Getter
+public class TeamLeaveRequest {
+
+    private Long userId;
+    private Long teamId;
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamRequest.java
@@ -1,0 +1,32 @@
+package CloudProject.A_meet.domain.group.domain.team.dto;
+
+import CloudProject.A_meet.domain.group.domain.team.domain.Team;
+import lombok.Getter;
+
+/**
+ * Team 생성 시 사용자로부터 입력받는 데이터를 담는 DTO 클래스
+ * - userId: 팀 생성 사용자 ID
+ * - teamName: 팀 이름
+ * - description: 팀 설명
+ * - teamPassword: 팀 입장 비밀번호
+ * - maxPeople: 팀 최대 멤버 수
+ */
+@Getter
+public class TeamRequest {
+
+    private Long userId;
+    private String teamName;
+    private String description;
+    private String teamPassword;
+    private Long maxPeople;
+
+    public Team toEntity() {
+        return Team.builder()
+                .name(teamName)
+                .description(description)
+                .teamPassword(teamPassword)
+                .maxPeople(maxPeople)
+                .build();
+    }
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/TeamResponse.java
@@ -1,0 +1,38 @@
+package CloudProject.A_meet.domain.group.domain.team.dto;
+
+import CloudProject.A_meet.domain.group.domain.team.domain.Team;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class TeamResponse {
+
+    private Long teamId;
+    private String name;
+    private String description;
+    private String password;
+    private Long maxPeople;
+    private int memberNum;
+    private LocalDateTime createdAt;
+    private List<UserTeamResponse> memberList;
+
+    public static TeamResponse of(Team team, List<UserTeamResponse> memberList) {
+        return TeamResponse.builder()
+                .teamId(team.getTeamId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .password(team.getTeamPassword())
+                .maxPeople(team.getMaxPeople())
+                .memberNum(memberList.size())
+                .createdAt(team.getCreatedAt())
+                .memberList(memberList)
+                .build();
+    }
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/repository/TeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/repository/TeamRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
     Optional<Team> findByTeamId(Long teamId);
+
+    Optional<Team> findByNameAndTeamPassword(String name, String password);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -7,7 +7,7 @@ import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
 
 public interface TeamService {
 
-    TeamResponse createTeam(TeamRequest teamRequest);
+    Long createTeam(TeamRequest teamRequest);
 
     TeamResponse getTeamInfo(Long teamId);
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -14,6 +14,4 @@ public interface TeamService {
     Long joinTeam(TeamEnterRequest teamEnterRequest);
 
     void leaveTeam(TeamLeaveRequest teamLeaveRequest);
-
-    TeamResponse rejoinTeam(TeamEnterRequest teamEnterRequest);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -4,6 +4,7 @@ import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
 
 public interface TeamService {
 
@@ -11,7 +12,7 @@ public interface TeamService {
 
     TeamResponse getTeamInfo(Long teamId);
 
-    Long joinTeam(TeamEnterRequest teamEnterRequest);
+    JoinResult joinTeam(TeamEnterRequest teamEnterRequest);
 
     void leaveTeam(TeamLeaveRequest teamLeaveRequest);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -13,7 +13,7 @@ public interface TeamService {
 
     Long joinTeam(TeamEnterRequest teamEnterRequest);
 
-    TeamResponse leaveTeam(TeamLeaveRequest teamLeaveRequest);
+    void leaveTeam(TeamLeaveRequest teamLeaveRequest);
 
     TeamResponse rejoinTeam(TeamEnterRequest teamEnterRequest);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -11,7 +11,7 @@ public interface TeamService {
 
     TeamResponse getTeamInfo(Long teamId);
 
-    TeamResponse joinTeam(TeamEnterRequest teamEnterRequest);
+    Long joinTeam(TeamEnterRequest teamEnterRequest);
 
     TeamResponse leaveTeam(TeamLeaveRequest teamLeaveRequest);
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -1,0 +1,19 @@
+package CloudProject.A_meet.domain.group.domain.team.service;
+
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
+
+public interface TeamService {
+
+    TeamResponse createTeam(TeamRequest teamRequest);
+
+    TeamResponse getTeamInfo(Long teamId);
+
+    TeamResponse joinTeam(TeamEnterRequest teamEnterRequest);
+
+    TeamResponse leaveTeam(TeamLeaveRequest teamLeaveRequest);
+
+    TeamResponse rejoinTeam(TeamEnterRequest teamEnterRequest);
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -91,6 +91,15 @@ public class TeamServiceImpl implements TeamService {
         return userTeam.getUserTeamId();
     }
 
+    /**
+     * 팀 스페이스 탈퇴
+     *
+     * @param teamLeaveRequest 팀 탈퇴에 필요한 정보 포함한 요청 객체
+     * @return void
+     * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     *                         TEAM_NOT_FOUND   팀이 존재하지 않을 경우
+     *                         USER_TEAM_NOT_FOUND 팀 유저(멤버)가 존재하지 않을 경우
+     * */
     @Override
     @Transactional
     public void leaveTeam(TeamLeaveRequest teamLeaveRequest) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -129,9 +129,4 @@ public class TeamServiceImpl implements TeamService {
         // 2. team 나가기
         userTeam.updateIsMember(false);
     }
-
-    @Override
-    public TeamResponse rejoinTeam(TeamEnterRequest teamEnterRequest) {
-        return null;
-    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -8,7 +8,6 @@ import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
-import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamResponse;
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
 import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
 import CloudProject.A_meet.domain.group.domain.user.domain.User;
@@ -18,10 +17,6 @@ import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,13 +30,12 @@ public class TeamServiceImpl implements TeamService {
      * 팀 스페이스 생성
      *
      * @param teamRequest 팀 생성에 필요한 정보 포함한 요청 객체
-     * @return TeamResponse 생성된 팀의 세부 정보를 포함한 응답 객체
+     * @return userTeamId 팀 생성자의 팀 유저 (멤버) ID
      * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
-     * @// TODO: 2024-11-08 반환 값 UserTeamId로 변경해도 될지?
      * */
     @Override
     @Transactional
-    public TeamResponse createTeam(TeamRequest teamRequest) {
+    public Long createTeam(TeamRequest teamRequest) {
 
         // 1. User 객체 조회
         User user = userRepository.findByUserId(teamRequest.getUserId())
@@ -59,12 +53,8 @@ public class TeamServiceImpl implements TeamService {
                 .build();
         userTeamRepository.save(userTeam);
 
-        // todo: List<UserTeamResponse> 반환 메서드 뽑아낼 수 있음 뽑기
-        // 4. TeamResponse 반환
-        List<UserTeamResponse> userTeamResponses = new ArrayList<>();
-        userTeamResponses.add(UserTeamResponse.of(userTeam));
-
-        return TeamResponse.of(team, userTeamResponses);
+        // 4. userTeamId 반환
+        return userTeam.getUserTeamId();
     }
 
     @Override
@@ -76,7 +66,7 @@ public class TeamServiceImpl implements TeamService {
      * 팀 스페이스 입장
      *
      * @param teamEnterRequest 팀 입장에 필요한 정보 포함한 요청 객체
-     * @return userTeamId 팀 유저 (멤버) ID
+     * @return userTeamId 팀 참가자의 팀 유저 (멤버) ID
      * @throws CustomException TEAM_CREDENTIALS_INVALID 팀 자격 증명 잘못됐을 경우
      * */
     @Override

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -55,6 +55,7 @@ public class TeamServiceImpl implements TeamService {
                 .teamId(team)
                 .userId(user)
                 .role(Role.OWNER)
+                .isMember(true)
                 .build();
         userTeamRepository.save(userTeam);
 
@@ -124,6 +125,7 @@ public class TeamServiceImpl implements TeamService {
                     .teamId(team)
                     .userId(user)
                     .role(Role.MEMBER)
+                    .isMember(true)
                     .build();
         }
         userTeamRepository.save(userTeam);

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -72,8 +73,32 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
+    @Transactional
     public TeamResponse joinTeam(TeamEnterRequest teamEnterRequest) {
-        return null;
+
+        // 1. Team 객체 조회
+        Team team = teamRepository.findByNameAndTeamPassword(teamEnterRequest.getTeamName(), teamEnterRequest.getTeamPassword())
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+        // 2. User 객체 조회 후, UserTeam 객체 생성
+        User user = userRepository.findByUserId(teamEnterRequest.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        UserTeam userTeam = UserTeam.builder()
+                .teamId(team)
+                .userId(user)
+                .role(Role.MEMBER)
+                .build();
+        userTeamRepository.save(userTeam);
+
+        // 3. Team Member 모두 조회 후, UserTeamResponse 생성
+        List<UserTeam> userTeams = userTeamRepository.findAllByTeamId(team);
+
+        List<UserTeamResponse> userTeamResponses = userTeams.stream()
+                        .map(UserTeamResponse::of)
+                                .collect(Collectors.toList());
+
+        return TeamResponse.of(team, userTeamResponses);
+
     }
 
     @Override

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -9,6 +9,7 @@ import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamResponse;
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
 import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
 import CloudProject.A_meet.domain.group.domain.user.domain.User;
@@ -18,6 +19,9 @@ import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -58,9 +62,28 @@ public class TeamServiceImpl implements TeamService {
         return userTeam.getUserTeamId();
     }
 
+    /**
+     * 팀 스페이스 조회
+     *
+     * @param teamId 입장하고자 하는 팀 스페이스 ID
+     * @return TeamResponse 팀 스페이스 정보 및 멤버 정보를 보함한 응답 객체
+     * @throws CustomException TEAM_CREDENTIALS_INVALID 팀 자격 증명 잘못됐을 경우
+     * */
     @Override
     public TeamResponse getTeamInfo(Long teamId) {
-        return null;
+
+        // 1. Team 객체 조회
+        Team team = teamRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+        // 2. UserTeam 객체 리스트 UserTeamResponse 로 변환
+        List<UserTeam> userTeams = userTeamRepository.findAllByTeamId(team);
+        List<UserTeamResponse> userTeamResponses = userTeams.stream()
+                .map(UserTeamResponse::of)
+                .collect(Collectors.toList());
+
+        // 3. Team 정보와 UserTeam(팀 멤버) 정보 담은 Response 객체 반환
+        return TeamResponse.of(team, userTeamResponses);
     }
 
     /**
@@ -71,6 +94,8 @@ public class TeamServiceImpl implements TeamService {
      *         1) userTeamId 팀 참가자의 팀 유저 (멤버) ID
      *         2) wasMember  탈퇴한 참가자인지 새로운 참가자인지 구분하는 boolean 값
      * @throws CustomException TEAM_CREDENTIALS_INVALID 팀 자격 증명 잘못됐을 경우
+     *                         MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     *                         USER_TEAM_NOT_FOUND 팀 유저(멤버)가 존재하지 않을 경우
      * */
     @Override
     @Transactional

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -69,17 +69,16 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public TeamResponse getTeamInfo(Long teamId) {
-
-        // 3. Team Member 모두 조회 후, UserTeamResponse 생성
-        List<UserTeam> userTeams = userTeamRepository.findAllByTeamId(team);
-
-        List<UserTeamResponse> userTeamResponses = userTeams.stream()
-                .map(UserTeamResponse::of)
-                .collect(Collectors.toList());
-
-        return TeamResponse.of(team, userTeamResponses);
+        return null;
     }
 
+    /**
+     * 팀 스페이스 입장
+     *
+     * @param teamEnterRequest 팀 입장에 필요한 정보 포함한 요청 객체
+     * @return userTeamId 팀 유저 (멤버) ID
+     * @throws CustomException TEAM_CREDENTIALS_INVALID 팀 자격 증명 잘못됐을 경우
+     * */
     @Override
     @Transactional
     public Long joinTeam(TeamEnterRequest teamEnterRequest) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -67,7 +67,9 @@ public class TeamServiceImpl implements TeamService {
      * 팀 스페이스 입장
      *
      * @param teamEnterRequest 팀 입장에 필요한 정보 포함한 요청 객체
-     * @return userTeamId 팀 참가자의 팀 유저 (멤버) ID
+     * @return JoinResult
+     *         1) userTeamId 팀 참가자의 팀 유저 (멤버) ID
+     *         2) wasMember  탈퇴한 참가자인지 새로운 참가자인지 구분하는 boolean 값
      * @throws CustomException TEAM_CREDENTIALS_INVALID 팀 자격 증명 잘못됐을 경우
      * */
     @Override

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -92,8 +92,20 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
-    public TeamResponse leaveTeam(TeamLeaveRequest teamLeaveRequest) {
-        return null;
+    @Transactional
+    public void leaveTeam(TeamLeaveRequest teamLeaveRequest) {
+
+        // 1. UserTeam 객체 조회
+        User user = userRepository.findByUserId(teamLeaveRequest.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Team team = teamRepository.findByTeamId(teamLeaveRequest.getTeamId())
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+        UserTeam userTeam = userTeamRepository.findByTeamIdAndUserId(team, user)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
+
+        // 2. team 나가기
+        userTeam.updateIsMember(false);
     }
 
     @Override

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -73,18 +73,31 @@ public class TeamServiceImpl implements TeamService {
     @Transactional
     public Long joinTeam(TeamEnterRequest teamEnterRequest) {
 
-        // 1. Team 객체 조회
+        // 1. Team 객체 조회 (team 입장 가능 여부 판단)
         Team team = teamRepository.findByNameAndTeamPassword(teamEnterRequest.getTeamName(), teamEnterRequest.getTeamPassword())
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_CREDENTIALS_INVALID));
 
-        // 2. User 객체 조회 후, UserTeam 객체 생성
+
+        // 2. User 객체 조회 후,
+        //    1) 탈퇴한 참가자의 경우, rejoin
+        //    2) 첫 참가자의 경우, UserTeam 객체 생성
         User user = userRepository.findByUserId(teamEnterRequest.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        UserTeam userTeam = UserTeam.builder()
-                .teamId(team)
-                .userId(user)
-                .role(Role.MEMBER)
-                .build();
+
+        boolean wasMember = userTeamRepository.existsByTeamIdAndUserId(team, user);
+        UserTeam userTeam;
+        if(wasMember) {
+            userTeam = userTeamRepository.findByTeamIdAndUserId(team, user)
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
+
+            userTeam.updateIsMember(true);
+        } else {
+            userTeam = UserTeam.builder()
+                    .teamId(team)
+                    .userId(user)
+                    .role(Role.MEMBER)
+                    .build();
+        }
         userTeamRepository.save(userTeam);
 
         // 3. userTeamId 반환

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -156,5 +156,23 @@ public class TeamServiceImpl implements TeamService {
 
         // 2. team 나가기
         userTeam.updateIsMember(false);
+        userTeamRepository.save(userTeam);
+
+        // 3. 예외처리 1) 팀에 남은 인원이 0명일 경우, 탈퇴한 멤버들과 팀 삭제
+        if(!userTeamRepository.existsByTeamIdAndIsMember(team, true)) {
+            deleteTeam(team);
+        }
+
+        // todo: 4. 예외처리 2) 팀의 OWNER가 탈퇴한 경우, 권한 재할당
+    }
+
+    void deleteTeam(Team team) {
+
+        // 1. 탈퇴한 팀 유저(멤버) 모두 삭제
+        List<UserTeam> userTeamsToDelete = userTeamRepository.findAllByTeamId(team);
+        userTeamsToDelete.forEach(userTeamRepository::delete);
+
+        // 2. 팀 삭제
+        teamRepository.delete(team);
     }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -15,7 +15,6 @@ import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,12 +36,13 @@ public class TeamServiceImpl implements TeamService {
      * @param teamRequest 팀 생성에 필요한 정보 포함한 요청 객체
      * @return TeamResponse 생성된 팀의 세부 정보를 포함한 응답 객체
      * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     * @// TODO: 2024-11-08 반환 값 UserTeamId로 변경해도 될지?
      * */
     @Override
     @Transactional
     public TeamResponse createTeam(TeamRequest teamRequest) {
 
-        // 1. User 정보 확인
+        // 1. User 객체 조회
         User user = userRepository.findByUserId(teamRequest.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -61,7 +61,7 @@ public class TeamServiceImpl implements TeamService {
         // todo: List<UserTeamResponse> 반환 메서드 뽑아낼 수 있음 뽑기
         // 4. TeamResponse 반환
         List<UserTeamResponse> userTeamResponses = new ArrayList<>();
-        userTeamResponses.add(UserTeamResponse.of(userTeam, user));
+        userTeamResponses.add(UserTeamResponse.of(userTeam));
 
         return TeamResponse.of(team, userTeamResponses);
     }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -158,6 +159,7 @@ public class TeamServiceImpl implements TeamService {
 
         // 2. team 나가기
         userTeam.updateIsMember(false);
+        userTeam.setUpdatedAt(LocalDateTime.now());
         userTeamRepository.save(userTeam);
 
         // 3. 예외처리 1) 팀에 남은 인원이 0명일 경우, 탈퇴한 멤버들과 팀 삭제
@@ -165,7 +167,10 @@ public class TeamServiceImpl implements TeamService {
             deleteTeam(team);
         }
 
-        // todo: 4. 예외처리 2) 팀의 OWNER가 탈퇴한 경우, 권한 재할당
+        // 4. 예외처리 2) 팀의 OWNER가 탈퇴한 경우, 권한 재할당
+        if(userTeam.getRole() == Role.OWNER) {
+            reassignOwnerRole(team, userTeam);
+        }
     }
 
     void deleteTeam(Team team) {
@@ -176,5 +181,19 @@ public class TeamServiceImpl implements TeamService {
 
         // 2. 팀 삭제
         teamRepository.delete(team);
+    }
+
+    void reassignOwnerRole(Team team, UserTeam userTeam) {
+        // 탈퇴하는 userTeam의 권한을 MEMBER로 변경
+        userTeam.updateRole(Role.MEMBER);
+        userTeamRepository.save(userTeam);
+
+        // 팀 멤버 중 가장 오래된 멤버를 OWNER로 설정
+        UserTeam oldestMember = userTeamRepository
+                .findFirstByTeamIdAndIsMemberOrderByUpdatedAtAsc(team, true)
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_MEMBERS_AVAILABLE));
+
+        oldestMember.updateRole(Role.OWNER);
+        userTeamRepository.save(oldestMember);
     }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -8,6 +8,7 @@ import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
 import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
 import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
 import CloudProject.A_meet.domain.group.domain.user.domain.User;
@@ -71,7 +72,7 @@ public class TeamServiceImpl implements TeamService {
      * */
     @Override
     @Transactional
-    public Long joinTeam(TeamEnterRequest teamEnterRequest) {
+    public JoinResult joinTeam(TeamEnterRequest teamEnterRequest) {
 
         // 1. Team 객체 조회 (team 입장 가능 여부 판단)
         Team team = teamRepository.findByNameAndTeamPassword(teamEnterRequest.getTeamName(), teamEnterRequest.getTeamPassword())
@@ -101,7 +102,7 @@ public class TeamServiceImpl implements TeamService {
         userTeamRepository.save(userTeam);
 
         // 3. userTeamId 반환
-        return userTeam.getUserTeamId();
+        return new JoinResult(userTeam.getUserTeamId(), wasMember);
     }
 
     /**

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -78,7 +78,7 @@ public class TeamServiceImpl implements TeamService {
 
         // 1. Team 객체 조회
         Team team = teamRepository.findByNameAndTeamPassword(teamEnterRequest.getTeamName(), teamEnterRequest.getTeamPassword())
-                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_CREDENTIALS_INVALID));
 
         // 2. User 객체 조회 후, UserTeam 객체 생성
         User user = userRepository.findByUserId(teamEnterRequest.getUserId())

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -69,12 +69,20 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public TeamResponse getTeamInfo(Long teamId) {
-        return null;
+
+        // 3. Team Member 모두 조회 후, UserTeamResponse 생성
+        List<UserTeam> userTeams = userTeamRepository.findAllByTeamId(team);
+
+        List<UserTeamResponse> userTeamResponses = userTeams.stream()
+                .map(UserTeamResponse::of)
+                .collect(Collectors.toList());
+
+        return TeamResponse.of(team, userTeamResponses);
     }
 
     @Override
     @Transactional
-    public TeamResponse joinTeam(TeamEnterRequest teamEnterRequest) {
+    public Long joinTeam(TeamEnterRequest teamEnterRequest) {
 
         // 1. Team 객체 조회
         Team team = teamRepository.findByNameAndTeamPassword(teamEnterRequest.getTeamName(), teamEnterRequest.getTeamPassword())
@@ -90,15 +98,8 @@ public class TeamServiceImpl implements TeamService {
                 .build();
         userTeamRepository.save(userTeam);
 
-        // 3. Team Member 모두 조회 후, UserTeamResponse 생성
-        List<UserTeam> userTeams = userTeamRepository.findAllByTeamId(team);
-
-        List<UserTeamResponse> userTeamResponses = userTeams.stream()
-                        .map(UserTeamResponse::of)
-                                .collect(Collectors.toList());
-
-        return TeamResponse.of(team, userTeamResponses);
-
+        // 3. userTeamId 반환
+        return userTeam.getUserTeamId();
     }
 
     @Override

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -1,0 +1,88 @@
+package CloudProject.A_meet.domain.group.domain.team.service.impl;
+
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.Role;
+import CloudProject.A_meet.domain.group.domain.team.domain.Team;
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
+import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
+import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamResponse;
+import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
+import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
+import CloudProject.A_meet.domain.group.domain.user.domain.User;
+import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
+import CloudProject.A_meet.global.common.error.exception.CustomException;
+import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TeamServiceImpl implements TeamService {
+
+    private final UserRepository userRepository;
+    private final UserTeamRepository userTeamRepository;
+    private final TeamRepository teamRepository;
+
+    /**
+     * 팀 스페이스 생성
+     *
+     * @param teamRequest 팀 생성에 필요한 정보 포함한 요청 객체
+     * @return TeamResponse 생성된 팀의 세부 정보를 포함한 응답 객체
+     * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     * */
+    @Override
+    @Transactional
+    public TeamResponse createTeam(TeamRequest teamRequest) {
+
+        // 1. User 정보 확인
+        User user = userRepository.findByUserId(teamRequest.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. TeamRequest 바탕으로 팀 생성
+        Team team = teamRequest.toEntity();
+        teamRepository.save(team);
+
+        // 3. UserTeam 생성
+        UserTeam userTeam = UserTeam.builder()
+                .teamId(team)
+                .userId(user)
+                .role(Role.OWNER)
+                .build();
+        userTeamRepository.save(userTeam);
+
+        // todo: List<UserTeamResponse> 반환 메서드 뽑아낼 수 있음 뽑기
+        // 4. TeamResponse 반환
+        List<UserTeamResponse> userTeamResponses = new ArrayList<>();
+        userTeamResponses.add(UserTeamResponse.of(userTeam, user));
+
+        return TeamResponse.of(team, userTeamResponses);
+    }
+
+    @Override
+    public TeamResponse getTeamInfo(Long teamId) {
+        return null;
+    }
+
+    @Override
+    public TeamResponse joinTeam(TeamEnterRequest teamEnterRequest) {
+        return null;
+    }
+
+    @Override
+    public TeamResponse leaveTeam(TeamLeaveRequest teamLeaveRequest) {
+        return null;
+    }
+
+    @Override
+    public TeamResponse rejoinTeam(TeamEnterRequest teamEnterRequest) {
+        return null;
+    }
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/controller/UserTeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/controller/UserTeamController.java
@@ -1,0 +1,32 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.controller;
+
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamIntroRequest;
+import CloudProject.A_meet.domain.group.domain.userTeam.service.UserTeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 팀 유저(멤버) 관련 Controller
+ * 멤버 한줄소개 작성 요청
+ *
+ * @author sungah
+ * */
+
+@RestController
+@RequestMapping("/api/v1/userTeam")
+@Tag(name = "UserTeam", description = "UserTeam API")
+@RequiredArgsConstructor
+public class UserTeamController {
+
+    private final UserTeamService userTeamService;
+
+    @Operation(summary = "write own introduction", description = "Use this when users create a team or enter the team")
+    @PutMapping("/introduction")
+    public ResponseEntity<?> writeIntroduction(@RequestBody UserTeamIntroRequest userTeamIntroRequest) {
+        userTeamService.writeIntroduction(userTeamIntroRequest);
+        return ResponseEntity.status(200).body(null);
+    }
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
@@ -33,9 +33,17 @@ public class UserTeam extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(length = 500)
     private String introduction;
+
+    @Column
+    private boolean isMember = true;
 
     public void updateIntro(String introduction) {
         this.introduction = introduction;
+    }
+
+    public void updateIsMember(boolean isMember) {
+        this.isMember = isMember;
     }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
@@ -23,7 +23,7 @@ public class UserTeam extends BaseTimeEntity {
     private Long userTeamId;
 
     @ManyToOne
-    @JoinColumn(name="userId")
+    @JoinColumn(name="user_id")
     private User userId;
 
     @ManyToOne
@@ -34,4 +34,8 @@ public class UserTeam extends BaseTimeEntity {
     private Role role;
 
     private String introduction;
+
+    public void updateIntro(String introduction) {
+        this.introduction = introduction;
+    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
@@ -46,4 +46,8 @@ public class UserTeam extends BaseTimeEntity {
     public void updateIsMember(boolean isMember) {
         this.isMember = isMember;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/domain/UserTeam.java
@@ -37,7 +37,7 @@ public class UserTeam extends BaseTimeEntity {
     private String introduction;
 
     @Column
-    private boolean isMember = true;
+    private boolean isMember;
 
     public void updateIntro(String introduction) {
         this.introduction = introduction;

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/JoinResult.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/JoinResult.java
@@ -1,5 +1,12 @@
 package CloudProject.A_meet.domain.group.domain.userTeam.dto;
 
+/**
+ * UserTeam 생성 및 입장 시 참여자 정보 및 상태값 다루기 위한 객체
+ * - userTeamId: 팀 참가자 ID
+ * - wasMember: 기존 팀 스페이스 참가자 구분값
+ *   1) true  : 탈퇴한 팀 스페이스 멤버 (재입장)
+ *   2) false : 새로운 팀 스페이스 멤버 (최초입장)
+ */
 public record JoinResult(Long userTeamId, boolean wasMember) {
 
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/JoinResult.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/JoinResult.java
@@ -1,0 +1,5 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.dto;
+
+public record JoinResult(Long userTeamId, boolean wasMember) {
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamIntroRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamIntroRequest.java
@@ -1,0 +1,17 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.dto;
+
+import lombok.Getter;
+
+/**
+ * UserTeam 생성 및 입장 시 사용자로부터 한줄 소개글 및 입장 정보를 담는 DTO 클래스
+ * - userId: 팀 생성자/참가자 ID
+ * - teamId: 생성 및 참가하려는 팀 스페이스 ID
+ * - introduction: 팀 유저(멤버) 본인 한 줄 소개글
+ */
+@Getter
+public class UserTeamIntroRequest {
+
+    private Long userTeamId;
+    private String introduction;
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
@@ -16,11 +16,11 @@ public class UserTeamResponse {
     private String nickname;
     private String introduction;
 
-    public static UserTeamResponse of(UserTeam userTeam, User user) {
+    public static UserTeamResponse of(UserTeam userTeam) {
         return UserTeamResponse.builder()
                 .userTeamId(userTeam.getUserTeamId())
                 .userId(userTeam.getUserId().getUserId())
-                .nickname(user.getNickname())
+                .nickname(userTeam.getUserId().getNickname())
                 .introduction(userTeam.getIntroduction())
                 .build();
     }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
@@ -1,0 +1,27 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.dto;
+
+import CloudProject.A_meet.domain.group.domain.user.domain.User;
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class UserTeamResponse {
+
+    private Long userTeamId;
+    private Long userId;
+    private String nickname;
+    private String introduction;
+
+    public static UserTeamResponse of(UserTeam userTeam, User user) {
+        return UserTeamResponse.builder()
+                .userTeamId(userTeam.getUserTeamId())
+                .userId(userTeam.getUserId().getUserId())
+                .nickname(user.getNickname())
+                .introduction(userTeam.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
@@ -1,5 +1,6 @@
 package CloudProject.A_meet.domain.group.domain.userTeam.dto;
 
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.Role;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,7 @@ public class UserTeamResponse {
 
     private Long userTeamId;
     private Long userId;
+    private Role role;
     private String nickname;
     private String introduction;
 
@@ -26,6 +28,7 @@ public class UserTeamResponse {
         return UserTeamResponse.builder()
                 .userTeamId(userTeam.getUserTeamId())
                 .userId(userTeam.getUserId().getUserId())
+                .role(userTeam.getRole())
                 .nickname(userTeam.getUserId().getNickname())
                 .introduction(userTeam.getIntroduction())
                 .build();

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
@@ -1,11 +1,17 @@
 package CloudProject.A_meet.domain.group.domain.userTeam.dto;
 
-import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * UserTeam (member) 상세 정보 반환 객체
+ * - userTeamId: 팀 유저(멤버) ID
+ * - userId: 사용자 ID
+ * - nickname: 사용자 닉네임
+ * - introduction: 팀 유저(멤버) 한 줄 소개
+ */
 @Builder
 @AllArgsConstructor
 @Getter

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -1,6 +1,7 @@
 package CloudProject.A_meet.domain.group.domain.userTeam.repository;
 
 import CloudProject.A_meet.domain.group.domain.team.domain.Team;
+import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,5 +14,9 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     Optional<UserTeam> findByUserTeamId(Long userTeamId);
 
+    Optional<UserTeam> findByTeamIdAndUserId(Team team, User user);
+
     List<UserTeam> findAllByTeamId(Team teamId);
+
+
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -20,5 +20,5 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     List<UserTeam> findAllByTeamId(Team teamId);
 
-
+    boolean existsByTeamIdAndIsMember(Team team, boolean isMember);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -16,6 +16,8 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     Optional<UserTeam> findByTeamIdAndUserId(Team team, User user);
 
+    boolean existsByTeamIdAndUserId(Team team, User user);
+
     List<UserTeam> findAllByTeamId(Team teamId);
 
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -2,6 +2,12 @@ package CloudProject.A_meet.domain.group.domain.userTeam.repository;
 
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
+
+    Optional<UserTeam> findByUserTeamId(Long userTeamId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -1,13 +1,17 @@
 package CloudProject.A_meet.domain.group.domain.userTeam.repository;
 
+import CloudProject.A_meet.domain.group.domain.team.domain.Team;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     Optional<UserTeam> findByUserTeamId(Long userTeamId);
+
+    List<UserTeam> findAllByTeamId(Team teamId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -21,4 +21,6 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     List<UserTeam> findAllByTeamId(Team teamId);
 
     boolean existsByTeamIdAndIsMember(Team team, boolean isMember);
+
+    Optional<UserTeam> findFirstByTeamIdAndIsMemberOrderByUpdatedAtAsc(Team team, boolean b);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/service/UserTeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/service/UserTeamService.java
@@ -1,0 +1,7 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.service;
+
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamIntroRequest;
+
+public interface UserTeamService {
+    void writeIntroduction(UserTeamIntroRequest introduction);
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/service/impl/UserTeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/service/impl/UserTeamServiceImpl.java
@@ -1,0 +1,38 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.service.impl;
+
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamIntroRequest;
+import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
+import CloudProject.A_meet.domain.group.domain.userTeam.service.UserTeamService;
+import CloudProject.A_meet.global.common.error.exception.CustomException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserTeamServiceImpl implements UserTeamService {
+
+    private final UserTeamRepository userTeamRepository;
+
+    /**
+     * 팀 유저(멤버) 본인 한 줄 소개글 작성
+     *
+     * @param userTeamIntroRequest 멤버 본인 한 줄 소개 작성에 필요한 정보 포함한 요청 객체
+     * @return void
+     * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     * */
+    @Override
+    @Transactional
+    public void writeIntroduction(UserTeamIntroRequest userTeamIntroRequest) {
+
+        // 1. userTeam 객체 조회
+        UserTeam userTeam = userTeamRepository.findByUserTeamId(userTeamIntroRequest.getUserTeamId())
+                .orElseThrow(() -> new EntityNotFoundException("UserTeam Not Found: " + userTeamIntroRequest.getUserTeamId()));
+
+        // 2. 멤버 한 줄 소개글 작성
+        userTeam.updateIntro(userTeamIntroRequest.getIntroduction());
+        userTeamRepository.save(userTeam);
+    }
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/service/impl/UserTeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/service/impl/UserTeamServiceImpl.java
@@ -5,7 +5,7 @@ import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamIntroRequest
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.service.UserTeamService;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
-import jakarta.persistence.EntityNotFoundException;
+import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +21,7 @@ public class UserTeamServiceImpl implements UserTeamService {
      *
      * @param userTeamIntroRequest 멤버 본인 한 줄 소개 작성에 필요한 정보 포함한 요청 객체
      * @return void
-     * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     * @throws CustomException USER_TEAM_NOT_FOUND 팀 유저(멤버)가 존재하지 않을 경우
      * */
     @Override
     @Transactional
@@ -29,7 +29,7 @@ public class UserTeamServiceImpl implements UserTeamService {
 
         // 1. userTeam 객체 조회
         UserTeam userTeam = userTeamRepository.findByUserTeamId(userTeamIntroRequest.getUserTeamId())
-                .orElseThrow(() -> new EntityNotFoundException("UserTeam Not Found: " + userTeamIntroRequest.getUserTeamId()));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
 
         // 2. 멤버 한 줄 소개글 작성
         userTeam.updateIntro(userTeamIntroRequest.getIntroduction());

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -30,7 +30,10 @@ public enum ErrorCode {
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회의록을 찾을 수 없습니다."),
 
     // UserTeam
-    USER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀 유저(멤버)를 찾을 수 없습니다.");
+    USER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀 유저(멤버)를 찾을 수 없습니다."),
+
+    // Team
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀을 찾을 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -33,7 +33,9 @@ public enum ErrorCode {
     USER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀 유저(멤버)를 찾을 수 없습니다."),
 
     // Team
-    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀을 찾을 수 없습니다.");
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀을 찾을 수 없습니다."),
+    TEAM_CREDENTIALS_INVALID(HttpStatus.BAD_REQUEST, "팀 이름 또는 비밀번호가 일치하지 않습니다.");;
+
 
 
     private final HttpStatus status;

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -31,10 +31,11 @@ public enum ErrorCode {
 
     // UserTeam
     USER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀 유저(멤버)를 찾을 수 없습니다."),
+    NO_MEMBERS_AVAILABLE(HttpStatus.BAD_REQUEST, "해당 조건을 만족하는 팀 유저(멤버)가 존재하지 않습니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀을 찾을 수 없습니다."),
-    TEAM_CREDENTIALS_INVALID(HttpStatus.BAD_REQUEST, "팀 이름 또는 비밀번호가 일치하지 않습니다.");;
+    TEAM_CREDENTIALS_INVALID(HttpStatus.BAD_REQUEST, "팀 이름 또는 비밀번호가 일치하지 않습니다.");
 
 
 

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -27,7 +27,10 @@ public enum ErrorCode {
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회의를 찾을 수 없습니다."),
 
     //Note
-    NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회의록을 찾을 수 없습니다.");
+    NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회의록을 찾을 수 없습니다."),
+
+    // UserTeam
+    USER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀 유저(멤버)를 찾을 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/CloudProject/A_meet/global/common/model/BaseTimeEntity.java
+++ b/src/main/java/CloudProject/A_meet/global/common/model/BaseTimeEntity.java
@@ -21,4 +21,8 @@ public abstract class BaseTimeEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- [ ] #17

## 💡 작업내용
1. 팀 생성, 입장, 탈퇴, 조회 로직 구현
2. 적절한 ErrorCode 추가
3. 팀 생성 또는 팀 입장 성공 이후, 팀 유저(멤버) 본인 한줄 소개글 작성할 수 있도록 api 분리
4. 팀 입장 또는 생성 api 반환값 TeamResponse > Long으로 변경 (∵3. 한줄 소개글 작성 api 분리)
5. UserTeam 테이블에 isMember 칼럼 추가
6. 팀 재입장 api 삭제 > 팀 입장 api에 rejoin 로직 추가
7. 팀 입장, 탈퇴 시 예외처리 구현


## 📝 기타
- 팀 탈퇴/재입장일 때마다 UserTeam 객체 새롭게 생성하는 것은 불필요하다고 생각하여,
isMember 칼럼을 추가해 탈퇴한 멤버와 현 멤버를 구분합니다.
- 팀 재입장 시 필요한 request 객체와 로직이 팀 입장 로직과 유사할 뿐만 아니라,
프론트 단에서는 사용자가 팀에 최초 입장하는지 재입장하는지 여부를 알 수 없어 api 구분해 호출할 수 없다고 판단.
재입장 api를 따로 생성하지 않고, joinTeam api에 rejoin 로직을 추가하였습니다.
최초 입장/재입장에 따라 userTeam 객체를 생성하거나 기존 userTeam 객체값을 수정하므로,
HttpStatus 상태 및 응답값을 각각 다르게 반환합니다.

- 예외처리
1. 잘못된 팀 자격 증명
2. 팀 멤버 존재하지 않을 경우, 팀 삭제
3. 팀 OWNER가 팀 탈퇴할 경우, OWNER 권한 재할당