### PR TITLE
[FEAT] 회의 로그 관련 API 개발 및 충돌 해결

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package CloudProject.A_meet.domain.group.domain.meeting.controller;
 
 import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingListResponse;
+import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingLogResponse;
 import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingRequest;
 import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingResponse;
 import CloudProject.A_meet.domain.group.domain.meeting.service.MeetingService;
@@ -43,6 +44,13 @@ public class MeetingController {
         List<MeetingResponse> meetingDataList = meetingService.getMeetingsByTeamId(teamId);
         MeetingListResponse meetingListResponse = new MeetingListResponse(meetingDataList);
         return ResponseEntity.status(200).body(meetingListResponse);
+    }
+
+    @Operation(summary = "Get Meeting Log by Team ID", description = "Fetch all meeting Logs for a specific team.")
+    @GetMapping("/log")
+    public ResponseEntity<List<MeetingLogResponse>> getMeetingLog(@RequestParam Long teamId) {
+        List<MeetingLogResponse> meetingLogResponses = meetingService.getMeetingLog(teamId);
+        return ResponseEntity.status(200).body(meetingLogResponses);
     }
 
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Table(name="meetings")
@@ -33,5 +34,5 @@ public class Meeting {
     @Column(nullable = false)
     private String title;
 
-    private Long duration;
+    private Duration duration;
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingLogResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingLogResponse.java
@@ -26,7 +26,7 @@ public class MeetingLogResponse {
     private Long meetingId;
     private String title;
     private LocalDateTime startedAt;
-    private Long duration;  // pull 땡기고 Duration 타입으로 변경
+    private Duration duration;
     private List<UserTeamBriefResponse> participantList;
 
     public static MeetingLogResponse of(Meeting meeting, List<UserTeamBriefResponse> participantList) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingLogResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingLogResponse.java
@@ -1,0 +1,41 @@
+package CloudProject.A_meet.domain.group.domain.meeting.dto;
+
+import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamBriefResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Meeting Log 목록 반환 객체
+ * - meetingId: 회의 ID
+ * - title: 회의 제목
+ * - startedAt: 회의 시작 일시
+ * - duration: 회의 소요시간
+ * - participantList: 회의 참여자 (팀 유저) 목록
+ */
+@Builder
+@AllArgsConstructor
+@Getter
+public class MeetingLogResponse {
+
+    private Long meetingId;
+    private String title;
+    private LocalDateTime startedAt;
+    private Long duration;
+    private List<UserTeamBriefResponse> participantList;
+
+    public static MeetingLogResponse of(Meeting meeting, List<UserTeamBriefResponse> participantList) {
+        return MeetingLogResponse.builder()
+                .meetingId(meeting.getMeetingId())
+                .title(meeting.getTitle())
+                .startedAt(meeting.getStartedAt())
+                .duration(meeting.getDuration())
+                .participantList(participantList)
+                .build();
+    }
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingLogResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingLogResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,7 +26,7 @@ public class MeetingLogResponse {
     private Long meetingId;
     private String title;
     private LocalDateTime startedAt;
-    private Long duration;
+    private Long duration;  // pull 땡기고 Duration 타입으로 변경
     private List<UserTeamBriefResponse> participantList;
 
     public static MeetingLogResponse of(Meeting meeting, List<UserTeamBriefResponse> participantList) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     List<Meeting> findByTeamId(Team teamId);
+
+    List<Meeting> findByTeamIdOrderByStartedAtDesc(Team teamId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
@@ -1,9 +1,13 @@
 package CloudProject.A_meet.domain.group.domain.meeting.repository;
 
+import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
+    List<UserMeeting> findAllByMeetingId(Meeting meetingId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
@@ -79,7 +79,7 @@ public class MeetingService {
         // 1. Meeting 객체 리스트 조회
         Team team = teamRepository.findByTeamId(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
-        List<Meeting> meetingList = meetingRepository.findByTeamId(team);
+        List<Meeting> meetingList = meetingRepository.findByTeamIdOrderByStartedAtDesc(team);
 
         // 2. MeetingLogResponse 반환
         if (!meetingList.isEmpty()) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
@@ -1,16 +1,25 @@
 package CloudProject.A_meet.domain.group.domain.meeting.service;
 
 import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
+import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
+import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingLogResponse;
 import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingRequest;
 import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingResponse;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
+import CloudProject.A_meet.domain.group.domain.meeting.repository.UserMeetingRepository;
 import CloudProject.A_meet.domain.group.domain.team.domain.Team;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
+import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamBriefResponse;
+import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
+import CloudProject.A_meet.global.common.error.exception.CustomException;
+import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,6 +29,8 @@ public class MeetingService {
 
     private final MeetingRepository meetingRepository;
     private final TeamRepository teamRepository;
+    private final UserMeetingRepository userMeetingRepository;
+    private final UserTeamRepository userTeamRepository;
 
     @Transactional
     public MeetingResponse createMeeting(MeetingRequest meetingRequest) {
@@ -61,5 +72,38 @@ public class MeetingService {
                         meeting.getDuration()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public List<MeetingLogResponse> getMeetingLog(Long teamId) {
+
+        // 1. Meeting 객체 리스트 조회
+        Team team = teamRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+        List<Meeting> meetingList = meetingRepository.findByTeamId(team);
+
+        // 2. MeetingLogResponse 반환
+        if (!meetingList.isEmpty()) {
+            return meetingList.stream()
+                    .map(meeting -> {
+                        // 1) 회의 참석자 모두 호출
+                        List<UserMeeting> userMeetings = userMeetingRepository.findAllByMeetingId(meeting);
+
+                        // 2) UserTeam 객체 조회해, UserTeamBriefResponse 리스트 생성
+                        // todo: 추후 UserTeamService로 메서드 분리 (재사용성 및 가독성 향상 위함)
+                        List<UserTeamBriefResponse> participantList = userMeetings.stream()
+                                .map(userMeeting -> {
+                                    UserTeam userTeam = userTeamRepository.findByUserTeamId(userMeeting.getUserTeamId().getUserTeamId())
+                                            .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
+                                    return UserTeamBriefResponse.of(userTeam);
+                                })
+                                .collect(Collectors.toList());
+
+                        // 3) MeetingLogResponse 객체 생성 및 반환
+                        return MeetingLogResponse.of(meeting, participantList);
+                    })
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamBriefResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamBriefResponse.java
@@ -1,0 +1,29 @@
+package CloudProject.A_meet.domain.group.domain.userTeam.dto;
+
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * UserTeam (member) 간략 정보 반환 객체
+ * - userTeamId: 팀 유저(멤버) ID
+ * - userId: 사용자 ID
+ * - nickname: 사용자 닉네임
+ */
+@Builder
+@AllArgsConstructor
+@Getter
+public class UserTeamBriefResponse {
+    private Long userTeamId;
+    private Long userId;
+    private String nickname;
+
+    public static UserTeamResponse of(UserTeam userTeam) {
+        return UserTeamResponse.builder()
+                .userTeamId(userTeam.getUserTeamId())
+                .userId(userTeam.getUserId().getUserId())
+                .nickname(userTeam.getUserId().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamBriefResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamBriefResponse.java
@@ -19,8 +19,8 @@ public class UserTeamBriefResponse {
     private Long userId;
     private String nickname;
 
-    public static UserTeamResponse of(UserTeam userTeam) {
-        return UserTeamResponse.builder()
+    public static UserTeamBriefResponse of(UserTeam userTeam) {
+        return UserTeamBriefResponse.builder()
                 .userTeamId(userTeam.getUserTeamId())
                 .userId(userTeam.getUserId().getUserId())
                 .nickname(userTeam.getUserId().getNickname())

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/dto/UserTeamResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
  * UserTeam (member) 상세 정보 반환 객체
  * - userTeamId: 팀 유저(멤버) ID
  * - userId: 사용자 ID
+ * - role: 팀 유저 권한 (OWNER, MEMBER)
  * - nickname: 사용자 닉네임
  * - introduction: 팀 유저(멤버) 한 줄 소개
  */


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #23 
- #26 

## 💡 작업내용
1. 회의 로그 목록 반환 로직 구현
2. 회의 로그 내림차순 정렬
3. develop 브랜치와의 충돌 해결
4. Meeting 엔티티 duration 자료형 변경
