### PR TITLE
[FEAT] 대시보드 관련 API 구현

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
@@ -53,4 +53,11 @@ public class MeetingController {
         return ResponseEntity.status(200).body(meetingLogResponses);
     }
 
+    @Operation(summary = "Get My Meeting Log by User ID", description = "Fetch all meeting Logs for a specific user.")
+    @GetMapping("/myLog")
+    public ResponseEntity<List<MeetingLogResponse>> getMyMeetingLog(@RequestParam Long userId) {
+        List<MeetingLogResponse> meetingLogResponses = meetingService.getMyMeetingLog(userId);
+        return ResponseEntity.status(200).body(meetingLogResponses);
+    }
+
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
@@ -2,6 +2,7 @@ package CloudProject.A_meet.domain.group.domain.meeting.repository;
 
 import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
+import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ import java.util.List;
 @Repository
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
     List<UserMeeting> findAllByMeetingId(Meeting meetingId);
+
+    List<UserMeeting> findAllByUserId(User user);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -144,6 +145,8 @@ public class MeetingService {
                         // 3) MeetingLogResponse 객체 생성
                         return MeetingLogResponse.of(meeting, participantList);
                     })
+                    // 회의 시작시간인 startedAt을 기준으로 내림차순 정렬해 반환
+                    .sorted(Comparator.comparing(MeetingLogResponse::getStartedAt).reversed())
                     .collect(Collectors.toList());
         } else {
             return Collections.emptyList();

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/MeetingService.java
@@ -9,6 +9,8 @@ import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingReposit
 import CloudProject.A_meet.domain.group.domain.meeting.repository.UserMeetingRepository;
 import CloudProject.A_meet.domain.group.domain.team.domain.Team;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
+import CloudProject.A_meet.domain.group.domain.user.domain.User;
+import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamBriefResponse;
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
@@ -31,6 +33,7 @@ public class MeetingService {
     private final TeamRepository teamRepository;
     private final UserMeetingRepository userMeetingRepository;
     private final UserTeamRepository userTeamRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public MeetingResponse createMeeting(MeetingRequest meetingRequest) {
@@ -99,6 +102,46 @@ public class MeetingService {
                                 .collect(Collectors.toList());
 
                         // 3) MeetingLogResponse 객체 생성 및 반환
+                        return MeetingLogResponse.of(meeting, participantList);
+                    })
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+    // 1. User 가 참여한 Meeting 객체 리스트 조회
+    // 1) User 객체 조회
+    // 2) UserMeeting 객체 조회 <- User 의 회의 참석 정보
+    // 3) Meeting 리스트 조회 <- UserMeeting
+    public List<MeetingLogResponse> getMyMeetingLog(Long userId) {
+
+        // 1. User 객체 조회
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. User의 UserMeeting 리스트 조회 (회의 참석 정보)
+        List<UserMeeting> userMeetingList = userMeetingRepository.findAllByUserId(user);
+
+        // 3. MeetingLogResponse 리스트 생성 및 반환
+        if (!userMeetingList.isEmpty()) {
+            return userMeetingList.stream()
+                    .map(userMeeting -> {
+                        // 1) Meeting ID를 통해 Meeting 객체 조회
+                        Meeting meeting = meetingRepository.findById(userMeeting.getUserMeetingId())
+                                .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
+
+                        // 2) UserMeeting 목록을 통해 참석자 리스트 생성
+                        // todo: 중복 메서드 뽑아내기
+                        List<UserMeeting> userMeetings = userMeetingRepository.findAllByMeetingId(meeting);
+                        List<UserTeamBriefResponse> participantList = userMeetings.stream()
+                                .map(um -> {
+                                    UserTeam userTeam = userTeamRepository.findByUserTeamId(um.getUserTeamId().getUserTeamId())
+                                            .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
+                                    return UserTeamBriefResponse.of(userTeam);
+                                })
+                                .collect(Collectors.toList());
+
+                        // 3) MeetingLogResponse 객체 생성
                         return MeetingLogResponse.of(meeting, participantList);
                     })
                     .collect(Collectors.toList());

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/controller/TeamController.java
@@ -1,9 +1,6 @@
 package CloudProject.A_meet.domain.group.domain.team.controller;
 
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
+import CloudProject.A_meet.domain.group.domain.team.dto.*;
 import CloudProject.A_meet.domain.group.domain.team.service.TeamService;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,9 +11,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * 팀 관련 Controller
- * 팀 생성, 조회, 참여/탈퇴/재참여 요청
+ * - 팀 생성, 조회, 참여/탈퇴/재참여 요청
+ * - 팀 목록 조회 요청
  *
  * @author sungah
  * */
@@ -57,6 +57,13 @@ public class TeamController {
     public ResponseEntity<?> leaveTeam(@RequestBody TeamLeaveRequest teamLeaveRequest) {
         teamService.leaveTeam(teamLeaveRequest);
         return ResponseEntity.status(200).body(null);
+    }
+
+    @Operation(summary = "Get All My TeamList", description = "Use this when you login (Sidebar)")
+    @PutMapping("/myTeamList")
+    public ResponseEntity<List<MyTeamResponse>> getMyTeamList(@RequestParam Long userId) {
+        List<MyTeamResponse> myTeamResponses = teamService.getMyTeamList(userId);
+        return ResponseEntity.status(200).body(myTeamResponses);
     }
 
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/MyTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/MyTeamResponse.java
@@ -1,0 +1,30 @@
+package CloudProject.A_meet.domain.group.domain.team.dto;
+
+import CloudProject.A_meet.domain.group.domain.team.domain.Team;
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class MyTeamResponse {
+
+    private Long teamId;
+    private String name;
+    private LocalDateTime createdAt;
+    private Role role;
+
+    public static MyTeamResponse of(Team team, Role role) {
+        return MyTeamResponse.builder()
+                .teamId(team.getTeamId())
+                .name(team.getName())
+                .createdAt(team.getCreatedAt())
+                .role(role)
+                .build();
+    }
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/MyTeamResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/dto/MyTeamResponse.java
@@ -8,6 +8,13 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+/**
+ * 특정 사용자가 속한 모든 Team 관련 간략한 정보를 담는 DTO 클래스
+ * - teamId: 팀 ID
+ * - name: 팀 이름
+ * - createdAt: 팀 생성일시
+ * - role: 해당 팀에서의 사용자 권한 (OWNER, MEMBER)
+ */
 @Builder
 @AllArgsConstructor
 @Getter

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/TeamService.java
@@ -1,10 +1,9 @@
 package CloudProject.A_meet.domain.group.domain.team.service;
 
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
+import CloudProject.A_meet.domain.group.domain.team.dto.*;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
+
+import java.util.List;
 
 public interface TeamService {
 
@@ -15,4 +14,6 @@ public interface TeamService {
     JoinResult joinTeam(TeamEnterRequest teamEnterRequest);
 
     void leaveTeam(TeamLeaveRequest teamLeaveRequest);
+
+    List<MyTeamResponse> getMyTeamList(Long userId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -1,12 +1,9 @@
 package CloudProject.A_meet.domain.group.domain.team.service.impl;
 
+import CloudProject.A_meet.domain.group.domain.team.dto.*;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.Role;
 import CloudProject.A_meet.domain.group.domain.team.domain.Team;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamEnterRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamLeaveRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamRequest;
-import CloudProject.A_meet.domain.group.domain.team.dto.TeamResponse;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.JoinResult;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamResponse;
@@ -21,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -170,6 +169,31 @@ public class TeamServiceImpl implements TeamService {
         // 4. 예외처리 2) 팀의 OWNER가 탈퇴한 경우, 권한 재할당
         if(userTeam.getRole() == Role.OWNER) {
             reassignOwnerRole(team, userTeam);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyTeamResponse> getMyTeamList(Long userId) {
+
+        // 1. User 객체 조회
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. 특정 사용자가 속한 Team 객체 조회 > MyTeamResponse 변환 > 리스트로 반환
+        List<UserTeam> userTeamList = userTeamRepository.findByUserIdAndIsMember(user, true);
+        if (!userTeamList.isEmpty()) {
+            return userTeamList.stream()
+                    .map(userTeam -> {
+                        Team team = teamRepository.findByTeamId(userTeam.getTeamId().getTeamId())
+                                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+                        return MyTeamResponse.of(team, userTeam.getRole());
+                    })
+                    .sorted(Comparator.comparing(MyTeamResponse::getCreatedAt).reversed())
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/team/service/impl/TeamServiceImpl.java
@@ -172,6 +172,14 @@ public class TeamServiceImpl implements TeamService {
         }
     }
 
+    /**
+     * 나의 팀 스페이스 목록 조회
+     *
+     * @param userId 로그인 한 사용자 ID
+     * @return MyTeamResponse 팀 스페이스 관련 정보를 포함한 응답 객체
+     * @throws CustomException MEMBER_NOT_FOUND 사용자가 존재하지 않을 경우
+     *                         TEAM_NOT_FOUND   팀이 존재하지 않을 경우
+     * */
     @Override
     @Transactional(readOnly = true)
     public List<MyTeamResponse> getMyTeamList(Long userId) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/userTeam/repository/UserTeamRepository.java
@@ -22,5 +22,7 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     boolean existsByTeamIdAndIsMember(Team team, boolean isMember);
 
-    Optional<UserTeam> findFirstByTeamIdAndIsMemberOrderByUpdatedAtAsc(Team team, boolean b);
+    Optional<UserTeam> findFirstByTeamIdAndIsMemberOrderByUpdatedAtAsc(Team team, boolean isMember);
+
+    List<UserTeam> findByUserIdAndIsMember(User user, boolean isMember);
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #25 

## 💡 작업내용
1. 사용자가 참여한 모든 회의 로그 목록 반환 로직
2. 사용자가 속한 모든 팀 목록 조회 로직
3. develop 브랜치 충돌 해결


## 📝 기타
- userTeam의 경우, isMemeber 값으로 현 멤버와 탈퇴한 멤버를 구분하고 있으므로
회의 로그 목록 반환 시, 탈퇴한 멤버를 참석자 목록에 포함하지 않도록 주의