### PR TITLE
Feat : 회의록 생성 시 S3 presignedUrl 생성 후 반환

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
@@ -35,4 +35,11 @@ public class Meeting {
     private String title;
 
     private Duration duration;
+
+    @Column(length = 2048)
+    private String presignedUrl;
+
+    public void setPresignedUrl(String presignedUrl) {
+        this.presignedUrl = presignedUrl;
+    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
@@ -36,7 +36,7 @@ public class Meeting {
 
     private Duration duration;
 
-    @Column(length = 2048)
+    @Column(nullable = false, length = 2048)
     private String presignedUrl;
 
     public void setPresignedUrl(String presignedUrl) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/dto/MeetingResponse.java
@@ -18,6 +18,7 @@ public class MeetingResponse {
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;
     private Duration duration;
+    private String presignedUrl;
 
     public void setDuration() {
         if (startedAt != null && endedAt != null) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -13,8 +13,11 @@ import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamBriefResponse;
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
+import CloudProject.A_meet.global.S3.S3Service;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import java.net.URL;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,6 +36,7 @@ public class MeetingServiceImpl implements MeetingService {
     private final UserTeamRepository userTeamRepository;
     private final UserMeetingRepository userMeetingRepository;
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     // 1. 회의 생성
     @Transactional
@@ -49,17 +53,26 @@ public class MeetingServiceImpl implements MeetingService {
 
         meetingRepository.save(newMeeting);
 
+        URL presignedUrl = createPresignedUrl(newMeeting.getMeetingId());
+        newMeeting.setPresignedUrl(presignedUrl.toString());
+
         // TODO: meeting join 구현
 
-        return new MeetingResponse(newMeeting.getMeetingId(), newMeeting.getTitle(), newMeeting.getStartedAt(), newMeeting.getEndedAt(), newMeeting.getDuration());
+        return new MeetingResponse(newMeeting.getMeetingId(), newMeeting.getTitle(), newMeeting.getStartedAt(), newMeeting.getEndedAt(), newMeeting.getDuration(),presignedUrl.toString());
     }
+
+    public URL createPresignedUrl(Long meetingId) {
+        String objectKey = "meetings/" + meetingId + "/.mp3";
+        return s3Service.generatePresignedUrl(objectKey, Duration.ofHours(1));
+    }
+
 
     // 2. 회의 상세 정보 조회
     public MeetingResponse getMeetingDetail(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
 
-        return new MeetingResponse(meeting.getMeetingId(), meeting.getTitle(), meeting.getStartedAt(), meeting.getEndedAt(), meeting.getDuration());
+        return new MeetingResponse(meeting.getMeetingId(), meeting.getTitle(), meeting.getStartedAt(), meeting.getEndedAt(), meeting.getDuration(), meeting.getPresignedUrl());
     }
 
 
@@ -77,7 +90,8 @@ public class MeetingServiceImpl implements MeetingService {
                         meeting.getTitle(),
                         meeting.getStartedAt(),
                         meeting.getEndedAt(),
-                        meeting.getDuration()
+                        meeting.getDuration(),
+                        meeting.getPresignedUrl()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -63,7 +63,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     public URL createPresignedUrl(Long meetingId) {
         String objectKey = "meetings/" + meetingId + "/.mp3";
-        return s3Service.generatePresignedUrl(objectKey, Duration.ofHours(1));
+        return s3Service.generatePresignedUrl(objectKey, Duration.ofHours(24));
     }
 
 

--- a/src/main/java/CloudProject/A_meet/global/S3/S3Service.java
+++ b/src/main/java/CloudProject/A_meet/global/S3/S3Service.java
@@ -1,0 +1,38 @@
+package CloudProject.A_meet.global.S3;
+
+import CloudProject.A_meet.global.common.error.exception.CustomException;
+import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public URL generatePresignedUrl(String key, Duration duration) {
+        try {
+            Date expiration = new Date(System.currentTimeMillis() + duration.toMillis());
+
+            GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, key)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration);
+
+            return amazonS3.generatePresignedUrl(presignedUrlRequest);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.S3_PreSignedURL_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
 
+    //AWS
+    S3_PreSignedURL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 PreSignedURL 생성에 실패했습니다."),
+
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     MEMBER_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 사용 중입니다."),


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #43

## 💡 작업내용
1. 회의록 생성 시 음성 파일 업로드를 위한 S3 PresignedUrl을 생성 후 반환하게 추가하였습니다.
2. ERD도 수정하였고, meetingResponse에 필드 추가하였습니다.
3. presignedUrl duration 우선 24시간으로 설정해두었습니다.

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/352f4170-5e2c-4fea-ad96-b82f19452231)


## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)