### PR TITLE
[Feat] 정리봇, 긍정 리액션, 부정 리액션 봇 구현

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/controller/BotController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/controller/BotController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class BotController {
     private final BotService botService;
 
-    @Operation(summary = "요약봇 호출", description = "회원 정보를 조회하는 API")
+    @Operation(summary = "정리봇 호출", description = "회원 정보를 조회하는 API")
     @GetMapping("/summary")
     public BotResponse summarize(@RequestParam Long meetingId) {
         return botService.summaryBot(meetingId);

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/controller/BotController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/controller/BotController.java
@@ -36,5 +36,4 @@ public class BotController {
     public BotResponse negative(@RequestParam Long meetingId) {
         return botService.negativeBot(meetingId);
     }
-
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/domain/Bot.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/domain/Bot.java
@@ -31,6 +31,7 @@ public class Bot {
     @Column(nullable = false)
     private BotType type;
 
+    @Column(length = 1000)
     private String content;
 
     @CreatedDate

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/domain/Bot.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/domain/Bot.java
@@ -36,4 +36,8 @@ public class Bot {
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -8,6 +8,7 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import CloudProject.A_meet.infra.service.BedrockService;
 import CloudProject.A_meet.infra.service.S3Service;
 import CloudProject.A_meet.infra.service.TranscribeService;
 import jakarta.transaction.Transactional;
@@ -22,6 +23,7 @@ public class BotService {
     private final MeetingRepository meetingRepository;
     private final TranscribeService transcribeservice;
     private final S3Service s3service;
+    private final BedrockService bedrockService;
 
     public BotResponse summaryBot(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
@@ -40,11 +42,10 @@ public class BotService {
         String transcriptionText = s3service.getTranscriptionResult(savedBot.getBotId());
 
         String prompt = "Summarize the following text:\n\n" + transcriptionText;
-        String summary = summarizeTextWithClaude(prompt);
+        String summary = bedrockService.invokeClaudeModel(prompt);
+        bot.updateContent(summary);
 
-
-
-        return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
+        return new BotResponse(meetingId, savedBot.getBotId(), summary);
     }
 
     public BotResponse positiveBot(Long meetingId) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -11,6 +11,8 @@ import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import CloudProject.A_meet.infra.service.BedrockService;
 import CloudProject.A_meet.infra.service.S3Service;
 import CloudProject.A_meet.infra.service.TranscribeService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -47,14 +49,38 @@ public class BotService {
 
         transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
         waitForTranscriptionJobCompletion(savedBot.getBotId());
-        String transcriptionText = s3service.getTranscriptionResult(savedBot.getBotId());
 
-        //String prompt = "Summarize the following text:\n\n" + transcriptionText;
-        //String summary = bedrockService.invokeClaudeModel(prompt);
-        //bot.updateContent(summary);
+        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId());
+        String transcriptionText = extractTranscriptionText(transcriptionJson);
 
-        return new BotResponse(meetingId, savedBot.getBotId(), transcriptionText);
+        int maxLength = 1000;
+        if (transcriptionText.length() > maxLength) {
+            transcriptionText = "..." + transcriptionText.substring(transcriptionText.length() - maxLength);
+        }
+
+        String prompt = "Summarize the following text:\n\n" + transcriptionText;
+        String summary = bedrockService.invokeClaudeModel(prompt);
+        bot.updateContent(summary);
+
+        return new BotResponse(meetingId, savedBot.getBotId(), summary);
     }
+
+    private String extractTranscriptionText(String jsonResponse) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode rootNode = objectMapper.readTree(jsonResponse);
+            JsonNode transcriptsNode = rootNode.path("results").path("transcripts");
+
+            if (transcriptsNode.isArray() && transcriptsNode.size() > 0) {
+                return transcriptsNode.get(0).path("transcript").asText();
+            } else {
+                throw new CustomException(ErrorCode.TRANSCRIPTION_TEXT_NOT_FOUND);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.JSON_PARSE_ERROR);
+        }
+    }
+
     private void waitForTranscriptionJobCompletion(Long botId) {
         String jobName = botId.toString(); // Transcription Job 이름
         int maxRetries = 20; // 최대 재시도 횟수
@@ -107,6 +133,27 @@ public class BotService {
                 .build();
 
         Bot savedBot = botRepository.save(bot);
+
+        String presignedUrl = meeting.getPresignedUrl();
+        String bucketName = "transcribe-input-cp";
+        String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
+        String s3Uri = "s3://" + bucketName + "/" + objectKey;
+
+        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
+        waitForTranscriptionJobCompletion(savedBot.getBotId());
+
+        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId());
+        String transcriptionText = extractTranscriptionText(transcriptionJson);
+
+        int maxLength = 1000;
+        if (transcriptionText.length() > maxLength) {
+            transcriptionText = "..." + transcriptionText.substring(transcriptionText.length() - maxLength);
+        }
+
+        String prompt = "긍정적인 리액션을 해줘:\n\n" + transcriptionText;
+        String summary = bedrockService.invokeClaudeModel(prompt);
+        bot.updateContent(summary);
+
         return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
     }
 
@@ -121,6 +168,26 @@ public class BotService {
                 .build();
 
         Bot savedBot = botRepository.save(bot);
+        String presignedUrl = meeting.getPresignedUrl();
+        String bucketName = "transcribe-input-cp";
+        String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
+        String s3Uri = "s3://" + bucketName + "/" + objectKey;
+
+        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
+        waitForTranscriptionJobCompletion(savedBot.getBotId());
+
+        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId());
+        String transcriptionText = extractTranscriptionText(transcriptionJson);
+
+        int maxLength = 1000;
+        if (transcriptionText.length() > maxLength) {
+            transcriptionText = "..." + transcriptionText.substring(transcriptionText.length() - maxLength);
+        }
+
+        String prompt = "현실감있는 리액션을 해줘:\n\n" + transcriptionText;
+        String summary = bedrockService.invokeClaudeModel(prompt);
+        bot.updateContent(summary);
+
         return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
     }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -8,6 +8,8 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import CloudProject.A_meet.infra.service.S3Service;
+import CloudProject.A_meet.infra.service.TranscribeService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,8 @@ import org.springframework.stereotype.Service;
 public class BotService {
     private final BotRepository botRepository;
     private final MeetingRepository meetingRepository;
+    private final TranscribeService transcribeservice;
+    private final S3Service s3service;
 
     public BotResponse summaryBot(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
@@ -30,6 +34,16 @@ public class BotService {
                 .build();
 
         Bot savedBot = botRepository.save(bot);
+
+        String presignedUrl = meeting.getPresignedUrl();
+        transcribeservice.startTranscriptionJob(presignedUrl, savedBot.getBotId());
+        String transcriptionText = s3service.getTranscriptionResult(savedBot.getBotId());
+
+        String prompt = "Summarize the following text:\n\n" + transcriptionText;
+        String summary = summarizeTextWithClaude(prompt);
+
+
+
         return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
     }
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -12,8 +12,11 @@ import CloudProject.A_meet.infra.service.BedrockService;
 import CloudProject.A_meet.infra.service.S3Service;
 import CloudProject.A_meet.infra.service.TranscribeService;
 import jakarta.transaction.Transactional;
+import java.net.MalformedURLException;
+import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.transcribe.model.TranscriptionJobStatus;
 
 @Service
 @Transactional
@@ -38,15 +41,60 @@ public class BotService {
         Bot savedBot = botRepository.save(bot);
 
         String presignedUrl = meeting.getPresignedUrl();
-        transcribeservice.startTranscriptionJob(presignedUrl, savedBot.getBotId());
+        String bucketName = "transcribe-input-cp";
+        String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
+        String s3Uri = "s3://" + bucketName + "/" + objectKey;
+
+        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
+        waitForTranscriptionJobCompletion(savedBot.getBotId());
         String transcriptionText = s3service.getTranscriptionResult(savedBot.getBotId());
 
-        String prompt = "Summarize the following text:\n\n" + transcriptionText;
-        String summary = bedrockService.invokeClaudeModel(prompt);
-        bot.updateContent(summary);
+        //String prompt = "Summarize the following text:\n\n" + transcriptionText;
+        //String summary = bedrockService.invokeClaudeModel(prompt);
+        //bot.updateContent(summary);
 
-        return new BotResponse(meetingId, savedBot.getBotId(), summary);
+        return new BotResponse(meetingId, savedBot.getBotId(), transcriptionText);
     }
+    private void waitForTranscriptionJobCompletion(Long botId) {
+        String jobName = botId.toString(); // Transcription Job 이름
+        int maxRetries = 20; // 최대 재시도 횟수
+        int retryInterval = 10000; // 재시도 간격 (10초)
+
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                Thread.sleep(retryInterval); // 대기
+
+                // Transcription 작업 상태 확인
+                TranscriptionJobStatus status = transcribeservice.getTranscriptionJobStatus(jobName);
+
+                if (status == TranscriptionJobStatus.COMPLETED) {
+                    System.out.println("Transcription job completed: " + jobName);
+                    return; // 작업 완료 시 메서드 종료
+                } else if (status == TranscriptionJobStatus.FAILED) {
+                    throw new CustomException(ErrorCode.TRANSCRIBE_JOB_FAILED);
+                }
+
+                System.out.println("Transcription job in progress: " + jobName + ", attempt: " + (attempt + 1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CustomException(ErrorCode.TRANSCRIBE_JOB_INTERRUPTED);
+            }
+        }
+
+        // 최대 재시도 횟수 초과 시 예외 처리
+        throw new CustomException(ErrorCode.TRANSCRIBE_JOB_TIMEOUT);
+    }
+
+    private String extractS3KeyFromPresignedUrl(String presignedUrl) {
+        try {
+            URL url = new URL(presignedUrl);
+            String path = url.getPath();
+            return path.startsWith("/") ? path.substring(1) : path;
+        } catch (MalformedURLException e) {
+            throw new CustomException(ErrorCode.INVALID_PRESIGNED_URL);
+        }
+    }
+
 
     public BotResponse positiveBot(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/ClaudeService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/ClaudeService.java
@@ -1,0 +1,12 @@
+package CloudProject.A_meet.domain.group.domain.bot.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ClaudeService {
+    
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/Meeting.java
@@ -36,7 +36,7 @@ public class Meeting {
 
     private Duration duration;
 
-    @Column(nullable = false, length = 2048)
+    @Column(length = 2048)
     private String presignedUrl;
 
     public void setPresignedUrl(String presignedUrl) {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -62,7 +62,7 @@ public class MeetingServiceImpl implements MeetingService {
     }
 
     public URL createPresignedUrl(Long meetingId) {
-        String objectKey = "meetings/" + meetingId + "/.mp3";
+        String objectKey = "meetings/" + meetingId + ".mp3";
         return s3Service.generatePresignedUrl(objectKey, Duration.ofHours(24));
     }
 

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -18,6 +18,11 @@ public enum ErrorCode {
     //AWS
     S3_PreSignedURL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 PreSignedURL 생성에 실패했습니다."),
     S3_FILE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 읽기에 실패했습니다."),
+    INVALID_PRESIGNED_URL(HttpStatus.BAD_REQUEST, "잘못된 Presigned URL 입니다."),
+    S3_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "S3 객체를 찾을 수 없습니다."),
+    TRANSCRIBE_JOB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Transcribe Job 생성에 실패했습니다."),
+    TRANSCRIBE_JOB_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "Transcribe Job이 중단되었습니다."),
+    TRANSCRIBE_JOB_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, "Transcribe Job이 시간 초과되었습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     TRANSCRIBE_JOB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Transcribe Job 생성에 실패했습니다."),
     TRANSCRIBE_JOB_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "Transcribe Job이 중단되었습니다."),
     TRANSCRIBE_JOB_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, "Transcribe Job이 시간 초과되었습니다."),
+    TRANSCRIPTION_TEXT_NOT_FOUND(HttpStatus.NOT_FOUND, "Transcription Text를 찾을 수 없습니다."),
+    JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),

--- a/src/main/java/CloudProject/A_meet/infra/config/BedrockConfig.java
+++ b/src/main/java/CloudProject/A_meet/infra/config/BedrockConfig.java
@@ -1,29 +1,53 @@
 package CloudProject.A_meet.infra.config;
 
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrock.BedrockClient;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 
 @Configuration
 public class BedrockConfig {
 
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * BedrockClient Bean 설정
+     */
     @Bean
     public BedrockClient bedrockClient() {
         return BedrockClient.builder()
-            .region(Region.AP_NORTHEAST_2)
-            .credentialsProvider(DefaultCredentialsProvider.create())
+            .region(Region.of(region))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                )
+            )
             .build();
     }
 
+    /**
+     * BedrockRuntimeAsyncClient Bean 설정
+     */
     @Bean
     public BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient() {
         return BedrockRuntimeAsyncClient.builder()
-            .region(Region.AP_NORTHEAST_2)
-            .credentialsProvider(DefaultCredentialsProvider.create())
+            .region(Region.of(region))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                )
+            )
             .build();
     }
 }

--- a/src/main/java/CloudProject/A_meet/infra/config/TranscribeConfig.java
+++ b/src/main/java/CloudProject/A_meet/infra/config/TranscribeConfig.java
@@ -1,19 +1,34 @@
 package CloudProject.A_meet.infra.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.transcribe.TranscribeClient;
 
 @Configuration
 public class TranscribeConfig {
 
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
     @Bean
     public TranscribeClient transcribeClient() {
         return TranscribeClient.builder()
-            .region(Region.AP_NORTHEAST_2)
-            .credentialsProvider(ProfileCredentialsProvider.create())
+            .region(Region.of(region)) // Region 설정
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                )
+            )
             .build();
     }
 }

--- a/src/main/java/CloudProject/A_meet/infra/service/BedrockService.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/BedrockService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.Executors;
 
 @Service
 @RequiredArgsConstructor
-public class ClaudeService {
+public class BedrockService {
 
     private final BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
     private final ExecutorService executorService = Executors.newCachedThreadPool();

--- a/src/main/java/CloudProject/A_meet/infra/service/BedrockService.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/BedrockService.java
@@ -1,6 +1,7 @@
 package CloudProject.A_meet.infra.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.SdkBytes;
@@ -12,18 +13,15 @@ import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BedrockService {
 
     private final BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
 
-    /**
-     * Claude 모델 호출 후 응답 반환
-     *
-     * @param prompt 사용자 입력 프롬프트
-     * @return 모델 응답 텍스트
-     */
     public String invokeClaudeModel(String prompt) {
         try {
+            log.info("Preparing payload for Claude model invocation.");
+
             var payload = new JSONObject()
                 .put("anthropic_version", "bedrock-2023-05-31")
                 .put("max_tokens", 1000)
@@ -31,48 +29,75 @@ public class BedrockService {
                     .put("role", "user")
                     .put("content", prompt));
 
-            // 요청 객체 생성
+            log.info("Payload prepared: {}", payload.toString());
+
             var request = InvokeModelWithResponseStreamRequest.builder()
                 .contentType("application/json")
                 .body(SdkBytes.fromUtf8String(payload.toString()))
-                .modelId("anthropic.claude-3-5-sonnet-20240620-v1:0")
+                .modelId("anthropic.claude-3-haiku-20240307-v1:0")
                 .build();
 
-            // 응답 스트림 핸들러
+            log.info("Request object created: {}", request);
+
             var responseFuture = new CompletableFuture<StringBuilder>();
             var handler = createResponseStreamHandler(responseFuture);
 
-            // Claude 모델 호출
+            log.info("Invoking Claude model...");
             bedrockRuntimeAsyncClient.invokeModelWithResponseStream(request, handler).join();
 
-            // CompletableFuture 결과 반환
+            log.info("Claude model invocation completed.");
+
             return responseFuture.join().toString();
         } catch (Exception e) {
+            log.error("Error during Claude model invocation: {}", e.getMessage(), e);
             throw new RuntimeException("Failed to invoke Claude model: " + e.getMessage(), e);
         }
     }
 
-    /**
-     * 응답 스트림 핸들러 생성
-     *
-     * @param responseFuture 모델 응답을 저장할 CompletableFuture
-     * @return InvokeModelWithResponseStreamResponseHandler
-     */
     private InvokeModelWithResponseStreamResponseHandler createResponseStreamHandler(CompletableFuture<StringBuilder> responseFuture) {
         StringBuilder responseBuilder = new StringBuilder();
 
         return InvokeModelWithResponseStreamResponseHandler.builder()
-            .onEventStream(stream -> stream.subscribe(event -> event.accept(
-                InvokeModelWithResponseStreamResponseHandler.Visitor.builder()
-                    .onChunk(c -> {
-                        // JSON으로 변환
-                        var chunk = new JSONObject(c.bytes().asUtf8String());
-                        var text = chunk.optJSONObject("delta").optString("text", "");
-                        responseBuilder.append(text);
-                    })
-                    .build())))
-            .onComplete(() -> responseFuture.complete(responseBuilder))
-            .onError(responseFuture::completeExceptionally)
+            .onEventStream(stream -> {
+                log.info("Processing response stream...");
+                stream.subscribe(event -> {
+                    try {
+                        event.accept(
+                            InvokeModelWithResponseStreamResponseHandler.Visitor.builder()
+                                .onChunk(c -> {
+                                    try {
+                                        var chunkData = c.bytes().asUtf8String();
+                                        log.debug("Received chunk data: {}", chunkData);
+
+                                        var chunk = new JSONObject(chunkData);
+                                        var delta = chunk.optJSONObject("delta");
+
+                                        if (delta != null) {
+                                            var text = delta.optString("text", "");
+                                            log.debug("Extracted text: {}", text);
+                                            responseBuilder.append(text);
+                                        } else {
+                                            log.warn("Delta object is null. Chunk: {}", chunkData);
+                                        }
+                                    } catch (Exception ex) {
+                                        log.error("Error processing chunk: {}", ex.getMessage(), ex);
+                                    }
+                                })
+                                .build()
+                        );
+                    } catch (Exception ex) {
+                        log.error("Error processing stream event: {}", ex.getMessage(), ex);
+                    }
+                });
+            })
+            .onComplete(() -> {
+                log.info("Response stream processing complete.");
+                responseFuture.complete(responseBuilder);
+            })
+            .onError(error -> {
+                log.error("Error during response stream processing: {}", error.getMessage(), error);
+                responseFuture.completeExceptionally(error);
+            })
             .build();
     }
 }

--- a/src/main/java/CloudProject/A_meet/infra/service/BedrockService.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/BedrockService.java
@@ -1,74 +1,66 @@
 package CloudProject.A_meet.infra.service;
-import lombok.RequiredArgsConstructor;
 
+import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelWithResponseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelWithResponseStreamResponseHandler;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
 public class BedrockService {
 
     private final BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
-    private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     /**
-     * Claude 모델의 실시간 응답을 SSE로 스트리밍
+     * Claude 모델 호출 후 응답 반환
      *
-     * @param prompt  사용자 입력 프롬프트
-     * @param emitter SseEmitter를 통해 클라이언트로 실시간 응답 전송
+     * @param prompt 사용자 입력 프롬프트
+     * @return 모델 응답 텍스트
      */
-    public void invokeClaudeModelWithSSE(String prompt, SseEmitter emitter) {
-        executorService.execute(() -> {
-            try {
-                var payload = new JSONObject()
-                    .put("anthropic_version", "bedrock-2023-05-31")
-                    .put("max_tokens", 1000)
-                    .append("messages", new JSONObject()
-                        .put("role", "user")
-                        .put("content", prompt));
+    public String invokeClaudeModel(String prompt) {
+        try {
+            var payload = new JSONObject()
+                .put("anthropic_version", "bedrock-2023-05-31")
+                .put("max_tokens", 1000)
+                .append("messages", new JSONObject()
+                    .put("role", "user")
+                    .put("content", prompt));
 
+            // 요청 객체 생성
+            var request = InvokeModelWithResponseStreamRequest.builder()
+                .contentType("application/json")
+                .body(SdkBytes.fromUtf8String(payload.toString()))
+                .modelId("anthropic.claude-3-5-sonnet-20240620-v1:0")
+                .build();
 
-                // 요청 객체 생성
-                var request = InvokeModelWithResponseStreamRequest.builder()
-                    .contentType("application/json")
-                    .body(SdkBytes.fromUtf8String(payload.toString()))
-                    .modelId("anthropic.claude-3-5-sonnet-20240620-v1:0")
-                    .build();
+            // 응답 스트림 핸들러
+            var responseFuture = new CompletableFuture<StringBuilder>();
+            var handler = createResponseStreamHandler(responseFuture);
 
-                // 응답 스트림 핸들러
-                var handler = createResponseStreamHandler(emitter);
+            // Claude 모델 호출
+            bedrockRuntimeAsyncClient.invokeModelWithResponseStream(request, handler).join();
 
-                // Claude 모델 호출
-                bedrockRuntimeAsyncClient.invokeModelWithResponseStream(request, handler).join();
-
-                // SSE 종료
-                emitter.complete();
-            } catch (Exception e) {
-                try {
-                    emitter.completeWithError(e); // 이 코드는 RuntimeException 처리만 필요
-                } catch (Exception ex) {
-                    throw new RuntimeException("Failed to complete SSE emitter: " + ex.getMessage(), ex);
-                }
-            }
-        });
+            // CompletableFuture 결과 반환
+            return responseFuture.join().toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke Claude model: " + e.getMessage(), e);
+        }
     }
 
     /**
      * 응답 스트림 핸들러 생성
      *
-     * @param emitter SseEmitter를 통해 실시간 응답 전송
+     * @param responseFuture 모델 응답을 저장할 CompletableFuture
      * @return InvokeModelWithResponseStreamResponseHandler
      */
-    private InvokeModelWithResponseStreamResponseHandler createResponseStreamHandler(SseEmitter emitter) {
+    private InvokeModelWithResponseStreamResponseHandler createResponseStreamHandler(CompletableFuture<StringBuilder> responseFuture) {
+        StringBuilder responseBuilder = new StringBuilder();
+
         return InvokeModelWithResponseStreamResponseHandler.builder()
             .onEventStream(stream -> stream.subscribe(event -> event.accept(
                 InvokeModelWithResponseStreamResponseHandler.Visitor.builder()
@@ -76,15 +68,11 @@ public class BedrockService {
                         // JSON으로 변환
                         var chunk = new JSONObject(c.bytes().asUtf8String());
                         var text = chunk.optJSONObject("delta").optString("text", "");
-
-                        // SSE로 클라이언트에 전송
-                        try {
-                            emitter.send(text);
-                        } catch (IOException e) {
-                            emitter.completeWithError(e);
-                        }
+                        responseBuilder.append(text);
                     })
                     .build())))
+            .onComplete(() -> responseFuture.complete(responseBuilder))
+            .onError(responseFuture::completeExceptionally)
             .build();
     }
 }

--- a/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
@@ -22,8 +22,8 @@ public class S3Service {
 
     private final AmazonS3 amazonS3;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucketName;
+    @Value("${cloud.aws.s3.input-bucket}")
+    private String inputBucket;
 
     @Value("${cloud.aws.s3.output-bucket")
     private String outputBucket;
@@ -32,7 +32,7 @@ public class S3Service {
         try {
             Date expiration = new Date(System.currentTimeMillis() + duration.toMillis());
 
-            GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, key)
+            GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(inputBucket, key)
                 .withMethod(HttpMethod.GET)
                 .withExpiration(expiration);
 

--- a/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
@@ -42,9 +42,9 @@ public class S3Service {
         }
     }
 
-    public String getTranscriptionResult(String key) {
+    public String getTranscriptionResult(Long botId) {
         try {
-            S3Object s3Object = amazonS3.getObject(outputBucket, key);
+            S3Object s3Object = amazonS3.getObject(outputBucket, botId.toString());
             InputStream inputStream = s3Object.getObjectContent();
             return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         } catch (Exception e) {

--- a/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
@@ -4,8 +4,10 @@ import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import java.util.Date;
 
 @Service
 @RequiredArgsConstructor
+
 public class S3Service {
 
     private final AmazonS3 amazonS3;
@@ -43,12 +46,24 @@ public class S3Service {
     }
 
     public String getTranscriptionResult(Long botId) {
+        String objectKey = botId + ".json";
+        System.out.println(outputBucket + objectKey);
         try {
-            S3Object s3Object = amazonS3.getObject(outputBucket, botId.toString());
+            S3Object s3Object = amazonS3.getObject("transcribe-output-cp", objectKey);
             InputStream inputStream = s3Object.getObjectContent();
             return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        } catch (Exception e) {
+
+        } catch (AmazonS3Exception e) {
+            // 객체가 존재하지 않는 경우
+            if (e.getStatusCode() == 404) {
+                System.err.println("S3 Object not found: " + objectKey);
+                throw new CustomException(ErrorCode.S3_OBJECT_NOT_FOUND);
+            }
+            throw new CustomException(ErrorCode.S3_FILE_READ_ERROR);
+
+        } catch (IOException e) {
             throw new CustomException(ErrorCode.S3_FILE_READ_ERROR);
         }
     }
+
 }

--- a/src/main/java/CloudProject/A_meet/infra/service/TranscribeService.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/TranscribeService.java
@@ -27,9 +27,8 @@ public class TranscribeService {
      * @return Transcription Job ID
      */
     public String startTranscriptionJob(String s3Url, Long botId) {
-        String jobName = "Transcription" + botId;
         StartTranscriptionJobRequest transcriptionJobRequest = StartTranscriptionJobRequest.builder()
-            .transcriptionJobName(jobName)
+            .transcriptionJobName(botId.toString())
             .media(Media.builder().mediaFileUri(s3Url).build())
             .identifyLanguage(true)
             .outputBucketName(bucketName)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,7 @@ cloud:
   aws:
     s3:
       bucket: ${S3_NAME}
+      input-bucket : ${S3_INPUT_NAME}
       output-bucket : ${S3_OUTPUT_NAME}
     stack.auto: false
     region.static: ${S3_REGION}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #47 

## 💡 작업내용
1. profile 이미지 업로드 버킷이랑 중복돼서 추가로 input 버킷 만들어줬습니다.
2. s3 -> transcribe -> bedrock 로직 구현
3. claude 3.5 sonnet이 요청 수 제한이 계속 걸려서 일단 haiku 모델로 설정했습니다.


## 📸 스크린샷(선택)

## 📝 기타
transcribe에서 bedrock까지 거치다보니 시간이 꽤 오래 걸려요..! 
스케쥴링해서 transcribe 작업을 미리 해놓는 것도 좋을 것 같습니다.