### PR TITLE
 [Feat] 실시간 음성 회의 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter'
+
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'com.google.code.gson:gson:2.8.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/SignalingHandler.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/SignalingHandler.java
@@ -1,0 +1,114 @@
+package CloudProject.A_meet.domain.group.domain.meeting.controller;
+
+import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
+import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
+import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
+import CloudProject.A_meet.domain.group.domain.meeting.repository.UserMeetingRepository;
+import CloudProject.A_meet.domain.group.domain.user.domain.User;
+import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
+import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
+import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
+import CloudProject.A_meet.global.common.error.exception.CustomException;
+import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+@RequiredArgsConstructor
+public class SignalingHandler extends TextWebSocketHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketHandler.class);
+    private final CopyOnWriteArrayList<WebSocketSession> sessions = new CopyOnWriteArrayList<>();
+    private final UserMeetingRepository userMeetingRepository;
+    private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+    private final UserTeamRepository userTeamRepository;
+
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        session.sendMessage(new TextMessage("Connected successfully"));
+
+        sessions.add(session);
+        logger.info("WebSocket connection established: {}", session.getId());
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+
+        JsonObject jsonMessage = JsonParser.parseString(message.getPayload()).getAsJsonObject();
+
+        // 최초 연결 시에만 DB에 저장
+        if (!session.getAttributes().containsKey("userMeetingId")) {
+
+            Long userId = jsonMessage.get("userId").getAsLong();
+            Long meetingId = jsonMessage.get("meetingId").getAsLong();
+            Long userTeamId = jsonMessage.get("userTeamId").getAsLong();
+
+            User user = userRepository.findByUserId(userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            Meeting meeting = meetingRepository.findByMeetingId(meetingId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
+
+            UserTeam userTeam = userTeamRepository.findByUserTeamId(userTeamId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
+
+            UserMeeting userMeeting = UserMeeting.builder()
+                    .userId(user)
+                    .meetingId(meeting)
+                    .userTeamId(userTeam)
+                    .entryTime(LocalDateTime.now())
+                    .build();
+
+            userMeetingRepository.save(userMeeting);
+
+            // 세션에 userMeetingId를 저장
+            session.getAttributes().put("userMeetingId", userMeeting.getUserMeetingId());
+
+            session.sendMessage(new TextMessage("User " + userId + " has joined the meeting " + meetingId));
+            logger.info("User {} has joined the meeting {}", userId, meetingId);
+        } else {
+            // 최초 연결 이후에는 메시지 전달만
+            for (WebSocketSession s : sessions) {
+                if (s.isOpen() && !s.getId().equals(session.getId())) {
+                    s.sendMessage(new TextMessage(message.getPayload()));
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        sessions.remove(session);
+
+        Long userMeetingId = (Long) session.getAttributes().get("userMeetingId");
+
+        if (userMeetingId != null) {
+            UserMeeting userMeeting = userMeetingRepository.findById(userMeetingId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
+
+            userMeeting.setExitTime(LocalDateTime.now());
+
+            userMeetingRepository.save(userMeeting);
+
+            logger.info("User {} has left the meeting {}", userMeeting.getUserId().getUserId(), userMeeting.getMeetingId().getMeetingId());
+        }
+
+        logger.info("WebSocket connection closed: {}", session.getId());
+    }
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/UserMeeting.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/domain/UserMeeting.java
@@ -35,9 +35,10 @@ public class UserMeeting {
     @JoinColumn(name="user_team_id")
     private UserTeam userTeamId;
 
+    @Setter
     @CreatedDate
     private LocalDateTime entryTime;
 
+    @Setter
     private LocalDateTime exitTime;
-
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
@@ -8,9 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    Optional<Meeting> findByMeetingId(Long MeetingId);
 
     List<Meeting> findByTeamId(Team teamId);
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -2,7 +2,10 @@ package CloudProject.A_meet.domain.group.domain.meeting.service.impl;
 
 import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
-import CloudProject.A_meet.domain.group.domain.meeting.dto.*;
+import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingLogResponse;
+import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingRequest;
+import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingResponse;
+import CloudProject.A_meet.domain.group.domain.meeting.dto.MeetingSearchRequest;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.UserMeetingRepository;
 import CloudProject.A_meet.domain.group.domain.meeting.service.MeetingService;
@@ -13,17 +16,17 @@ import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
 import CloudProject.A_meet.domain.group.domain.userTeam.dto.UserTeamBriefResponse;
 import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
-import CloudProject.A_meet.infra.service.S3Service;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
-import java.net.URL;
-import java.time.Duration;
+import CloudProject.A_meet.infra.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URL;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,8 +58,6 @@ public class MeetingServiceImpl implements MeetingService {
 
         URL presignedUrl = createPresignedUrl(newMeeting.getMeetingId());
         newMeeting.setPresignedUrl(presignedUrl.toString());
-
-        // TODO: meeting join 구현
 
         return new MeetingResponse(newMeeting.getMeetingId(), newMeeting.getTitle(), newMeeting.getStartedAt(), newMeeting.getEndedAt(), newMeeting.getDuration(),presignedUrl.toString());
     }

--- a/src/main/java/CloudProject/A_meet/global/config/WebRtcConfig.java
+++ b/src/main/java/CloudProject/A_meet/global/config/WebRtcConfig.java
@@ -16,7 +16,7 @@ public class WebRtcConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(signalingHandler, "/webrtc")
+        registry.addHandler(signalingHandler, "/api/v1/meeting/join")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }

--- a/src/main/java/CloudProject/A_meet/global/config/WebRtcConfig.java
+++ b/src/main/java/CloudProject/A_meet/global/config/WebRtcConfig.java
@@ -1,0 +1,23 @@
+package CloudProject.A_meet.global.config;
+
+import CloudProject.A_meet.domain.group.domain.meeting.controller.SignalingHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class WebRtcConfig implements WebSocketConfigurer {
+
+    @Autowired
+    private SignalingHandler signalingHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(signalingHandler, "/webrtc")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #51

## 💡 작업내용
- WebRTC를 활용하여 실시간 회의 구현 (비디오, 음성)
- 처음 /api/v1/meeting/join로 접속한 경우 entryTime 저장, 통신이 끊기면 exitTime 저장
- 최초 회의 생성자는 회의 생성 api 호출 후 회의에 참가하는 api를 호출해야 함

## 📸 스크린샷(선택)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)