### PR TITLE
[Feat] 회의록 수동 생성 구현

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -8,7 +8,9 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.domain.group.domain.meeting.service.impl.MeetingServiceImpl;
 import CloudProject.A_meet.domain.group.domain.note.domain.Note;
+import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
 import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
+import CloudProject.A_meet.domain.group.domain.note.repository.NoteRepository;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import CloudProject.A_meet.infra.service.BedrockService;
@@ -33,6 +35,7 @@ public class BotService {
     private final TranscribeService transcribeservice;
     private final S3Service s3service;
     private final BedrockService bedrockService;
+    private final NoteRepository noteRepository;
 
     public BotResponse summaryBot(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
@@ -195,28 +198,13 @@ public class BotService {
         return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
     }
 
-    public UploadResponse uploadFile(){
-        Note note = Note.builder()
-            .title("Note title")
-            .content("Note content")
-            .build();
+    public NoteResponse createNote(Long noteId) {
+        Note note = noteRepository.findByNoteId(noteId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
 
-        String s3key = "note/" + note.getNoteId() + ".mp3";
-        URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
-        return new UploadResponse(note.getNoteId(), presignedUrl.toString());
-    }
-
-
-    public BotResponse createNote() {
-        Note note = Note.builder()
-            .title("Note title")
-            .content("Note content")
-            .build();
-
-        String s3key = "note/" + note.getNoteId() + ".mp3";
-        URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
+        String presignedUrl = note.getPresignedUrl();
         String bucketName = "transcribe-input-cp";
-        String objectKey = extractS3KeyFromPresignedUrl(presignedUrl.toString());
+        String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
         String s3Uri = "s3://" + bucketName + "/" + objectKey;
 
         String keyName = "note" + note.getNoteId();
@@ -232,9 +220,9 @@ public class BotService {
             transcriptionText = "..." + transcriptionText.substring(transcriptionText.length() - maxLength);
         }
 
-        String prompt = "현실감있는 리액션을 해줘:\n\n" + transcriptionText;
+        String prompt = "내용을 요약해줘:\n\n" + transcriptionText;
         String summary = bedrockService.invokeClaudeModel(prompt);
-        bot.updateContent(summary);
+        note.updateContent(summary);
+        return new NoteResponse(null, note.getNoteId(), note.getTitle(), note.getContent(), note.getPresignedUrl(), note.getCreatedAt());
     }
-
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -6,6 +6,8 @@ import CloudProject.A_meet.domain.group.domain.bot.dto.BotResponse;
 import CloudProject.A_meet.domain.group.domain.bot.repository.BotRepository;
 import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
+import CloudProject.A_meet.domain.group.domain.meeting.service.impl.MeetingServiceImpl;
+import CloudProject.A_meet.domain.group.domain.note.domain.Note;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import CloudProject.A_meet.infra.service.BedrockService;
@@ -16,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.transcribe.model.TranscriptionJobStatus;
@@ -47,10 +50,10 @@ public class BotService {
         String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
         String s3Uri = "s3://" + bucketName + "/" + objectKey;
 
-        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
-        waitForTranscriptionJobCompletion(savedBot.getBotId());
+        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId().toString());
+        waitForTranscriptionJobCompletion(savedBot.getBotId().toString());
 
-        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId());
+        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId().toString());
         String transcriptionText = extractTranscriptionText(transcriptionJson);
 
         int maxLength = 1000;
@@ -81,8 +84,8 @@ public class BotService {
         }
     }
 
-    private void waitForTranscriptionJobCompletion(Long botId) {
-        String jobName = botId.toString(); // Transcription Job 이름
+    private void waitForTranscriptionJobCompletion(String botId) {
+        String jobName = botId; // Transcription Job 이름
         int maxRetries = 20; // 최대 재시도 횟수
         int retryInterval = 10000; // 재시도 간격 (10초)
 
@@ -139,10 +142,10 @@ public class BotService {
         String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
         String s3Uri = "s3://" + bucketName + "/" + objectKey;
 
-        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
-        waitForTranscriptionJobCompletion(savedBot.getBotId());
+        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId().toString());
+        waitForTranscriptionJobCompletion(savedBot.getBotId().toString());
 
-        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId());
+        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId().toString());
         String transcriptionText = extractTranscriptionText(transcriptionJson);
 
         int maxLength = 1000;
@@ -173,10 +176,10 @@ public class BotService {
         String objectKey = extractS3KeyFromPresignedUrl(presignedUrl);
         String s3Uri = "s3://" + bucketName + "/" + objectKey;
 
-        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId());
-        waitForTranscriptionJobCompletion(savedBot.getBotId());
+        transcribeservice.startTranscriptionJob(s3Uri, savedBot.getBotId().toString());
+        waitForTranscriptionJobCompletion(savedBot.getBotId().toString());
 
-        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId());
+        String transcriptionJson = s3service.getTranscriptionResult(savedBot.getBotId().toString());
         String transcriptionText = extractTranscriptionText(transcriptionJson);
 
         int maxLength = 1000;
@@ -190,4 +193,29 @@ public class BotService {
 
         return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
     }
+
+    public BotResponse createNote() {
+        Note note = Note.builder()
+                .title("Note title")
+                .content("Note content")
+                .build();
+
+        String s3key = "note/" + note.getNoteId() + ".mp3";
+        URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
+        String bucketName = "transcribe-input-cp";
+        String objectKey = extractS3KeyFromPresignedUrl(presignedUrl.toString());
+        String s3Uri = "s3://" + bucketName + "/" + objectKey;
+
+        String keyName = "note"+ note.getNoteId();
+
+        transcribeservice.startTranscriptionJob(s3Uri, keyName);
+        waitForTranscriptionJobCompletion(keyName);
+
+        String transcriptionJson = s3service.getTranscriptionResult(keyName);
+        String transcriptionText = extractTranscriptionText(transcriptionJson);
+
+        int maxLength = 1000;
+        if (transcriptionText.length() > maxLength) {
+            transcriptionText = "..." + transcription
+
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -199,8 +199,8 @@ public class BotService {
     }
 
     public NoteResponse createNote(Long noteId) {
-        Note note = noteRepository.findByNoteId(noteId)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
+        // 트랜잭션으로 제한할 부분만 래핑
+        Note note = transactionalFindByNoteId(noteId);
 
         String presignedUrl = note.getPresignedUrl();
         String bucketName = "transcribe-input-cp";
@@ -222,7 +222,21 @@ public class BotService {
 
         String prompt = "내용을 요약해줘:\n\n" + transcriptionText;
         String summary = bedrockService.invokeClaudeModel(prompt);
-        note.updateContent(summary);
+
+        // 트랜잭션으로 감쌀 부분
+        updateNoteContent(note, summary);
         return new NoteResponse(null, note.getNoteId(), note.getTitle(), note.getContent(), note.getPresignedUrl(), note.getCreatedAt());
     }
+
+    @Transactional
+    public Note transactionalFindByNoteId(Long noteId) {
+        return noteRepository.findByNoteId(noteId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateNoteContent(Note note, String summary) {
+        note.updateContent(summary);
+    }
+
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -203,7 +203,7 @@ public class BotService {
 
         String s3key = "note/" + note.getNoteId() + ".mp3";
         URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
-        return new UploadResponse(presignedUrl.toString());
+        return new UploadResponse(note.getNoteId(), presignedUrl.toString());
     }
 
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/bot/service/BotService.java
@@ -8,6 +8,7 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.domain.group.domain.meeting.service.impl.MeetingServiceImpl;
 import CloudProject.A_meet.domain.group.domain.note.domain.Note;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import CloudProject.A_meet.infra.service.BedrockService;
@@ -194,11 +195,23 @@ public class BotService {
         return new BotResponse(meetingId, savedBot.getBotId(), savedBot.getContent());
     }
 
+    public UploadResponse uploadFile(){
+        Note note = Note.builder()
+            .title("Note title")
+            .content("Note content")
+            .build();
+
+        String s3key = "note/" + note.getNoteId() + ".mp3";
+        URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
+        return new UploadResponse(presignedUrl.toString());
+    }
+
+
     public BotResponse createNote() {
         Note note = Note.builder()
-                .title("Note title")
-                .content("Note content")
-                .build();
+            .title("Note title")
+            .content("Note content")
+            .build();
 
         String s3key = "note/" + note.getNoteId() + ".mp3";
         URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
@@ -206,7 +219,7 @@ public class BotService {
         String objectKey = extractS3KeyFromPresignedUrl(presignedUrl.toString());
         String s3Uri = "s3://" + bucketName + "/" + objectKey;
 
-        String keyName = "note"+ note.getNoteId();
+        String keyName = "note" + note.getNoteId();
 
         transcribeservice.startTranscriptionJob(s3Uri, keyName);
         waitForTranscriptionJobCompletion(keyName);
@@ -216,6 +229,12 @@ public class BotService {
 
         int maxLength = 1000;
         if (transcriptionText.length() > maxLength) {
-            transcriptionText = "..." + transcription
+            transcriptionText = "..." + transcriptionText.substring(transcriptionText.length() - maxLength);
+        }
+
+        String prompt = "현실감있는 리액션을 해줘:\n\n" + transcriptionText;
+        String summary = bedrockService.invokeClaudeModel(prompt);
+        bot.updateContent(summary);
+    }
 
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
@@ -3,6 +3,7 @@ package CloudProject.A_meet.domain.group.domain.note.controller;
 import CloudProject.A_meet.domain.group.domain.bot.dto.BotResponse;
 import CloudProject.A_meet.domain.group.domain.bot.service.BotService;
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 import CloudProject.A_meet.domain.group.domain.note.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,7 +36,13 @@ public class NoteController {
         return ResponseEntity.status(200).body(noteResponse);
     }
 
-    @Operation(summary = "회의록 수동 생성", description = "회의록 수동 생성 API")
+    @Operation(summary = "회의록 수동 생성(업로드 API)", description = "회의록 수동 생성 API")
+    @GetMapping("/upload")
+    public UploadResponse uploadFile() {
+        return botService.uploadFile();
+    }
+
+    @Operation(summary = "회의록 수동 생성(회의록 반환 API)", description = "회의록 수동 생성 API")
     @GetMapping("/create")
     public BotResponse createNote() {
         return botService.createNote();

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
@@ -1,5 +1,7 @@
 package CloudProject.A_meet.domain.group.domain.note.controller;
 
+import CloudProject.A_meet.domain.group.domain.bot.dto.BotResponse;
+import CloudProject.A_meet.domain.group.domain.bot.service.BotService;
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
 import CloudProject.A_meet.domain.group.domain.note.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,8 +25,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Note", description = "Note API")
 @RequiredArgsConstructor
 public class NoteController {
-
     private final NoteService noteService;
+    private final BotService botService;
 
     @Operation(summary = "Get Note Detail", description = "Fetch detailed information for a specific note.")
     @GetMapping
@@ -32,4 +34,11 @@ public class NoteController {
         NoteResponse noteResponse = noteService.getNoteDetail(meetingId);
         return ResponseEntity.status(200).body(noteResponse);
     }
+
+    @Operation(summary = "회의록 수동 생성", description = "회의록 수동 생성 API")
+    @GetMapping("/create")
+    public BotResponse createNote() {
+        return botService.createNote();
+    }
+
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
@@ -3,13 +3,16 @@ package CloudProject.A_meet.domain.group.domain.note.controller;
 import CloudProject.A_meet.domain.group.domain.bot.dto.BotResponse;
 import CloudProject.A_meet.domain.group.domain.bot.service.BotService;
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadRequest;
 import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 import CloudProject.A_meet.domain.group.domain.note.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,9 +40,10 @@ public class NoteController {
     }
 
     @Operation(summary = "회의록 수동 생성(업로드 API)", description = "회의록 수동 생성 API")
-    @GetMapping("/upload")
-    public UploadResponse uploadFile() {
-        return botService.uploadFile();
+    @PostMapping("/upload")
+    public UploadResponse uploadFile(@RequestBody UploadRequest uploadRequest) {
+        UploadResponse uploadResponse = noteService.uploadFile(uploadRequest.getTitle(), uploadRequest.getMembers(), uploadRequest.getDateTime());
+        return ResponseEntity.status(201).body(uploadResponse);
     }
 
     @Operation(summary = "회의록 수동 생성(회의록 반환 API)", description = "회의록 수동 생성 API")

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/controller/NoteController.java
@@ -1,18 +1,18 @@
 package CloudProject.A_meet.domain.group.domain.note.controller;
 
-import CloudProject.A_meet.domain.group.domain.bot.dto.BotResponse;
 import CloudProject.A_meet.domain.group.domain.bot.service.BotService;
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
 import CloudProject.A_meet.domain.group.domain.note.dto.UploadRequest;
 import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 import CloudProject.A_meet.domain.group.domain.note.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/note")
 @Tag(name = "Note", description = "Note API")
 @RequiredArgsConstructor
+@Validated
 public class NoteController {
     private final NoteService noteService;
     private final BotService botService;
@@ -41,15 +42,16 @@ public class NoteController {
 
     @Operation(summary = "회의록 수동 생성(업로드 API)", description = "회의록 수동 생성 API")
     @PostMapping("/upload")
-    public UploadResponse uploadFile(@RequestBody UploadRequest uploadRequest) {
-        UploadResponse uploadResponse = noteService.uploadFile(uploadRequest.getTitle(), uploadRequest.getMembers(), uploadRequest.getDateTime());
+    public ResponseEntity<UploadResponse> uploadFile(@RequestBody UploadRequest uploadRequest) {
+        UploadResponse uploadResponse = noteService.uploadFile(uploadRequest);
         return ResponseEntity.status(201).body(uploadResponse);
     }
 
     @Operation(summary = "회의록 수동 생성(회의록 반환 API)", description = "회의록 수동 생성 API")
     @GetMapping("/create")
-    public BotResponse createNote() {
-        return botService.createNote();
+    public ResponseEntity<NoteResponse> createNote(@RequestParam Long noteId) {
+        NoteResponse noteResponse = botService.createNote(noteId);
+        return ResponseEntity.status(200).body(noteResponse);
     }
 
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.attoparser.dom.Text;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Table(name="note")
@@ -37,7 +38,7 @@ public class Note extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10000)
     private String content;
 
     @Column(length = 1000)

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
@@ -35,5 +35,11 @@ public class Note extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    private String fileUrl;
+    private String presignedUrl;
+
+    private String members;
+
+    public void updatePresignedUrl(String presignedUrl) {
+        this.presignedUrl = presignedUrl;
+    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
@@ -1,8 +1,13 @@
 package CloudProject.A_meet.domain.group.domain.note.domain;
 
 import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
+import CloudProject.A_meet.global.common.error.exception.CustomException;
+import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import CloudProject.A_meet.global.common.model.BaseTimeEntity;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,11 +40,29 @@ public class Note extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
+    @Column(length = 1000)
     private String presignedUrl;
 
     private String members;
 
     public void updatePresignedUrl(String presignedUrl) {
         this.presignedUrl = presignedUrl;
+    }
+    public void updateCreatedAt(String createdAt) {
+        if (createdAt == null || createdAt.isBlank()) {
+            throw new IllegalArgumentException("Invalid dateTime: dateTime cannot be null or empty");
+        }
+        try {
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            LocalDateTime parsedDate = LocalDateTime.parse(createdAt, formatter);
+            this.createdAt = parsedDate;
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.INVALID_DATE_FORMAT);
+        }
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
     }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/domain/Note.java
@@ -4,6 +4,8 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.global.common.model.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -11,8 +13,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Table(name="note")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @ToString
+@Builder
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Note extends BaseTimeEntity {

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/NoteResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/NoteResponse.java
@@ -11,12 +11,11 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 public class NoteResponse {
-
     private Long meetingId;
     private Long noteId;
     private String title;
     private String content;
-    private String fileUrl;
+    private String presignedUrl;
     private LocalDateTime createdAt;
 
     public static NoteResponse of(Note note) {
@@ -25,7 +24,7 @@ public class NoteResponse {
                 .noteId(note.getNoteId())
                 .title(note.getTitle())
                 .content(note.getContent())
-                .fileUrl(note.getPresignedUrl())
+                .presignedUrl(note.getPresignedUrl())
                 .createdAt(note.getCreatedAt())
                 .build();
     }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/NoteResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/NoteResponse.java
@@ -25,7 +25,7 @@ public class NoteResponse {
                 .noteId(note.getNoteId())
                 .title(note.getTitle())
                 .content(note.getContent())
-                .fileUrl(note.getFileUrl())
+                .fileUrl(note.getPresignedUrl())
                 .createdAt(note.getCreatedAt())
                 .build();
     }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadRequest.java
@@ -1,11 +1,14 @@
 package CloudProject.A_meet.domain.group.domain.note.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class UploadRequest {
     @JsonProperty("title")
     private String title;

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadRequest.java
@@ -1,10 +1,18 @@
 package CloudProject.A_meet.domain.group.domain.note.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class UploadRequest {
+    @JsonProperty("title")
     private String title;
+
+    @JsonProperty("members")
     private String members;
-    private String dateTime;
+
+    @JsonProperty("createdDate")
+    private String createdDate;
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadRequest.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadRequest.java
@@ -1,0 +1,10 @@
+package CloudProject.A_meet.domain.group.domain.note.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UploadRequest {
+    private String title;
+    private String members;
+    private String dateTime;
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadResponse.java
@@ -8,6 +8,13 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class UploadResponse {
+    Long NoteId;
     String presignedUrl;
 
+    public static UploadResponse of(Long NoteId, String presignedUrl) {
+        return UploadResponse.builder()
+                .NoteId(NoteId)
+                .presignedUrl(presignedUrl)
+                .build();
+    }
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadResponse.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/dto/UploadResponse.java
@@ -1,0 +1,13 @@
+package CloudProject.A_meet.domain.group.domain.note.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class UploadResponse {
+    String presignedUrl;
+
+}

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/repository/NoteRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/repository/NoteRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface NoteRepository extends JpaRepository<Note, Long> {
     Optional<Note> findByMeetingId(Meeting meetingId);
+    Optional<Note> findByNoteId(Long noteId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/NoteService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/NoteService.java
@@ -1,9 +1,12 @@
 package CloudProject.A_meet.domain.group.domain.note.service;
 
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 
 public interface NoteService {
 
     // 1. 회의록 상세 조회
     NoteResponse getNoteDetail(Long meetingId);
+
+    UploadResponse uploadFile(String title, String members, String dateTime);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/NoteService.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/NoteService.java
@@ -1,6 +1,7 @@
 package CloudProject.A_meet.domain.group.domain.note.service;
 
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadRequest;
 import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 
 public interface NoteService {
@@ -8,5 +9,5 @@ public interface NoteService {
     // 1. 회의록 상세 조회
     NoteResponse getNoteDetail(Long meetingId);
 
-    UploadResponse uploadFile(String title, String members, String dateTime);
+    UploadResponse uploadFile(UploadRequest request);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/impl/NoteServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/impl/NoteServiceImpl.java
@@ -4,6 +4,7 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.domain.group.domain.note.domain.Note;
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadRequest;
 import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 import CloudProject.A_meet.domain.group.domain.note.repository.NoteRepository;
 import CloudProject.A_meet.domain.group.domain.note.service.NoteService;
@@ -50,12 +51,14 @@ public class NoteServiceImpl implements NoteService {
 
     @Override
     @Transactional
-    public UploadResponse uploadFile(String title, String members, String dateTime) {
+    public UploadResponse uploadFile(UploadRequest request) {
         Note note = Note.builder()
-            .title(title)
+            .title(request.getTitle())
             .content("content")
-            .members(members)
+            .members(request.getMembers())
             .build();
+        noteRepository.save(note);
+        note.updateCreatedAt(request.getCreatedDate());
         String s3key = "note/" + note.getNoteId() + ".mp3";
         URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
         note.updatePresignedUrl(presignedUrl.toString());

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/impl/NoteServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/note/service/impl/NoteServiceImpl.java
@@ -4,10 +4,14 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.domain.group.domain.note.domain.Note;
 import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
+import CloudProject.A_meet.domain.group.domain.note.dto.UploadResponse;
 import CloudProject.A_meet.domain.group.domain.note.repository.NoteRepository;
 import CloudProject.A_meet.domain.group.domain.note.service.NoteService;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
+import CloudProject.A_meet.infra.service.S3Service;
+import java.net.URL;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,7 @@ public class NoteServiceImpl implements NoteService {
 
     private final MeetingRepository meetingRepository;
     private final NoteRepository noteRepository;
+    private final S3Service s3service;
 
     /**
      * 회의록 상세 정보 조회
@@ -41,5 +46,19 @@ public class NoteServiceImpl implements NoteService {
 
         // 3. 회의 반환 객체로 반환
         return NoteResponse.of(note);
+    }
+
+    @Override
+    @Transactional
+    public UploadResponse uploadFile(String title, String members, String dateTime) {
+        Note note = Note.builder()
+            .title(title)
+            .content("content")
+            .members(members)
+            .build();
+        String s3key = "note/" + note.getNoteId() + ".mp3";
+        URL presignedUrl = s3service.generatePresignedUrl(s3key, Duration.ofHours(24));
+        note.updatePresignedUrl(presignedUrl.toString());
+        return new UploadResponse(note.getNoteId(), presignedUrl.toString());
     }
 }

--- a/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/CloudProject/A_meet/global/common/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 한 값의 Type이 일치하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 잘못되었습니다."),
 
     //AWS
     S3_PreSignedURL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 PreSignedURL 생성에 실패했습니다."),
@@ -40,6 +41,7 @@ public enum ErrorCode {
 
     //Note
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회의록을 찾을 수 없습니다."),
+
 
     // UserTeam
     USER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팀 유저(멤버)를 찾을 수 없습니다."),

--- a/src/main/java/CloudProject/A_meet/global/common/model/BaseTimeEntity.java
+++ b/src/main/java/CloudProject/A_meet/global/common/model/BaseTimeEntity.java
@@ -16,7 +16,7 @@ public abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
     private LocalDateTime updatedAt;

--- a/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/S3Service.java
@@ -45,7 +45,7 @@ public class S3Service {
         }
     }
 
-    public String getTranscriptionResult(Long botId) {
+    public String getTranscriptionResult(String botId) {
         String objectKey = botId + ".json";
         System.out.println(outputBucket + objectKey);
         try {

--- a/src/main/java/CloudProject/A_meet/infra/service/TranscribeService.java
+++ b/src/main/java/CloudProject/A_meet/infra/service/TranscribeService.java
@@ -26,9 +26,9 @@ public class TranscribeService {
      * @param s3Url S3 Pre-signed URL
      * @return Transcription Job ID
      */
-    public String startTranscriptionJob(String s3Url, Long botId) {
+    public String startTranscriptionJob(String s3Url, String botId) {
         StartTranscriptionJobRequest transcriptionJobRequest = StartTranscriptionJobRequest.builder()
-            .transcriptionJobName(botId.toString())
+            .transcriptionJobName(botId)
             .media(Media.builder().mediaFileUri(s3Url).build())
             .identifyLanguage(true)
             .outputBucketName(bucketName)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #57 

## 💡 작업내용
### 1. 음성 파일 업로드 API 구현
- s3 presignedUrl, noteId 반환
### 2. 회의록 반환 API 구현
- 해당 nodeId로 요청하면 transcribe -> bedrock -> 회의록 반환

## 📸 스크린샷(선택)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)