### PR TITLE
[REFACTOR] 페이징 처리 속도 개선

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
@@ -52,10 +52,7 @@ public class MeetingController {
             @RequestParam Long teamId,
             @RequestParam int page,
             @RequestParam int size) {
-        long startTimeNew = System.currentTimeMillis();
         Page<MeetingLogResponse> meetingLogResponses = meetingService.getMeetingLog(teamId, PageRequest.of(page, size));
-        long endTimeNew = System.currentTimeMillis();
-        System.out.println("Execution time for modified code: " + (endTimeNew - startTimeNew) + " ms");
         return ResponseEntity.status(200).body(meetingLogResponses);
     }
 
@@ -65,10 +62,7 @@ public class MeetingController {
             @RequestParam Long userId,
             @RequestParam int page,
             @RequestParam int size) {
-        long startTimeNew = System.currentTimeMillis();
         Page<MeetingLogResponse> meetingLogResponses = meetingService.getMyMeetingLog(userId, PageRequest.of(page, size));
-        long endTimeNew = System.currentTimeMillis();
-        System.out.println("Execution time for modified code: " + (endTimeNew - startTimeNew) + " ms");
         return ResponseEntity.status(200).body(meetingLogResponses);
     }
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/MeetingController.java
@@ -52,7 +52,10 @@ public class MeetingController {
             @RequestParam Long teamId,
             @RequestParam int page,
             @RequestParam int size) {
+        long startTimeNew = System.currentTimeMillis();
         Page<MeetingLogResponse> meetingLogResponses = meetingService.getMeetingLog(teamId, PageRequest.of(page, size));
+        long endTimeNew = System.currentTimeMillis();
+        System.out.println("Execution time for modified code: " + (endTimeNew - startTimeNew) + " ms");
         return ResponseEntity.status(200).body(meetingLogResponses);
     }
 
@@ -62,7 +65,10 @@ public class MeetingController {
             @RequestParam Long userId,
             @RequestParam int page,
             @RequestParam int size) {
+        long startTimeNew = System.currentTimeMillis();
         Page<MeetingLogResponse> meetingLogResponses = meetingService.getMyMeetingLog(userId, PageRequest.of(page, size));
+        long endTimeNew = System.currentTimeMillis();
+        System.out.println("Execution time for modified code: " + (endTimeNew - startTimeNew) + " ms");
         return ResponseEntity.status(200).body(meetingLogResponses);
     }
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
@@ -5,6 +5,7 @@ import CloudProject.A_meet.domain.group.domain.team.domain.Team;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,6 +19,12 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findByTeamId(Team teamId);
 
     Page<Meeting> findByTeamIdOrderByStartedAtDesc(Team teamId, Pageable pageable);
+    @Query("SELECT m FROM Meeting m " +
+            "JOIN FETCH m.participants " +
+            "WHERE m.teamId = :team " +
+            "ORDER BY m.startedAt DESC")
+    Page<Meeting> findByTeamIdOrderByStartedAtDescWithParticipants(Team team, Pageable pageable);
+
 
     List<Meeting> findByTeamIdAndTitleContaining(Team team, String keyword);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/MeetingRepository.java
@@ -18,7 +18,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     List<Meeting> findByTeamId(Team teamId);
 
-    Page<Meeting> findByTeamIdOrderByStartedAtDesc(Team teamId, Pageable pageable);
     @Query("SELECT m FROM Meeting m " +
             "JOIN FETCH m.participants " +
             "WHERE m.teamId = :team " +

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
@@ -2,7 +2,6 @@ package CloudProject.A_meet.domain.group.domain.meeting.repository;
 
 import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
-import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,13 +10,10 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
     List<UserMeeting> findAllByMeetingId(Meeting meetingId);
-
-    Page<UserMeeting> findAllByUserId(User user, Pageable pageable);
 
     @Query("SELECT um FROM UserMeeting um " +
             "JOIN FETCH um.meetingId m " +
@@ -26,5 +22,4 @@ public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> 
 
     List<UserMeeting> findByMeetingId(Meeting meetingId);
 
-    Optional<UserMeeting> findByUserIdAndMeetingId(User userId, Meeting meetingId);
 }

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/repository/UserMeetingRepository.java
@@ -6,6 +6,8 @@ import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,6 +18,11 @@ public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> 
     List<UserMeeting> findAllByMeetingId(Meeting meetingId);
 
     Page<UserMeeting> findAllByUserId(User user, Pageable pageable);
+
+    @Query("SELECT um FROM UserMeeting um " +
+            "JOIN FETCH um.meetingId m " +
+            "WHERE um.userId.userId = :userId")
+    Page<UserMeeting> findAllByUserIdWithMeetings(@Param("userId") Long userId, Pageable pageable);
 
     List<UserMeeting> findByMeetingId(Meeting meetingId);
 

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -15,9 +15,6 @@ import CloudProject.A_meet.domain.group.domain.note.dto.NoteResponse;
 import CloudProject.A_meet.domain.group.domain.note.repository.NoteRepository;
 import CloudProject.A_meet.domain.group.domain.team.domain.Team;
 import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
-import CloudProject.A_meet.domain.group.domain.user.domain.User;
-import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
-import CloudProject.A_meet.domain.group.domain.userTeam.repository.UserTeamRepository;
 import CloudProject.A_meet.global.common.error.exception.CustomException;
 import CloudProject.A_meet.global.common.error.exception.ErrorCode;
 import CloudProject.A_meet.infra.service.S3Service;
@@ -40,9 +37,7 @@ import java.util.stream.Collectors;
 public class MeetingServiceImpl implements MeetingService {
     private final MeetingRepository meetingRepository;
     private final TeamRepository teamRepository;
-    private final UserTeamRepository userTeamRepository;
     private final UserMeetingRepository userMeetingRepository;
-    private final UserRepository userRepository;
     private final S3Service s3Service;
     private final BotService botService;
     private final NoteRepository noteRepository;
@@ -117,7 +112,7 @@ public class MeetingServiceImpl implements MeetingService {
         // 1. 페이징 처리 된 Meeting 객체 리스트 조회
         Team team = teamRepository.findByTeamId(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
-        Page<Meeting> meetingPage = meetingRepository.findByTeamIdOrderByStartedAtDesc(team, pageable);
+        Page<Meeting> meetingPage = meetingRepository.findByTeamIdOrderByStartedAtDescWithParticipants(team, pageable);
 
         // 2. 회의 참가자 목록 조회 후, MeetingLogResponse 객체로 반환
         return meetingPage.map(meeting -> MeetingLogResponse.of(meeting));

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -135,23 +135,8 @@ public class MeetingServiceImpl implements MeetingService {
     @Transactional(readOnly = true)
     public Page<MeetingLogResponse> getMyMeetingLog(Long userId, Pageable pageable) {
 
-        // 1. User 객체 조회
-        User user = userRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        // 2. User의 UserMeeting 리스트 조회 (회의 참석 정보)
-        // Page<UserMeeting> userMeetingPage = userMeetingRepository.findAllByUserId(user, pageable);
         Page<UserMeeting> userMeetingPage = userMeetingRepository.findAllByUserIdWithMeetings(userId, pageable);
 
-//        // 3. MeetingLogResponse 리스트 생성 및 반환
-//        return userMeetingPage.map(userMeeting -> {
-//            // 1) Meeting ID를 통해 Meeting 객체 조회
-//            Meeting meeting = meetingRepository.findById(userMeeting.getUserMeetingId())
-//                    .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
-//
-//            // 2) 회의 참가자 목록 조회 후, MeetingLogResponse 객체로 반환
-//            return MeetingLogResponse.of(meeting);
-//        });
         return userMeetingPage.map(userMeeting -> {
             Meeting meeting = userMeeting.getMeetingId(); // 이미 FETCH된 Meeting 객체 사용
             return MeetingLogResponse.of(meeting);

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -120,7 +120,7 @@ public class MeetingServiceImpl implements MeetingService {
         Page<Meeting> meetingPage = meetingRepository.findByTeamIdOrderByStartedAtDesc(team, pageable);
 
         // 2. 회의 참가자 목록 조회 후, MeetingLogResponse 객체로 반환
-        return meetingPage.map(this::getParticipantList);
+        return meetingPage.map(meeting -> MeetingLogResponse.of(meeting));
     }
 
     /**
@@ -140,16 +140,21 @@ public class MeetingServiceImpl implements MeetingService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 2. User의 UserMeeting 리스트 조회 (회의 참석 정보)
-        Page<UserMeeting> userMeetingPage = userMeetingRepository.findAllByUserId(user, pageable);
+        // Page<UserMeeting> userMeetingPage = userMeetingRepository.findAllByUserId(user, pageable);
+        Page<UserMeeting> userMeetingPage = userMeetingRepository.findAllByUserIdWithMeetings(userId, pageable);
 
-        // 3. MeetingLogResponse 리스트 생성 및 반환
+//        // 3. MeetingLogResponse 리스트 생성 및 반환
+//        return userMeetingPage.map(userMeeting -> {
+//            // 1) Meeting ID를 통해 Meeting 객체 조회
+//            Meeting meeting = meetingRepository.findById(userMeeting.getUserMeetingId())
+//                    .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
+//
+//            // 2) 회의 참가자 목록 조회 후, MeetingLogResponse 객체로 반환
+//            return MeetingLogResponse.of(meeting);
+//        });
         return userMeetingPage.map(userMeeting -> {
-            // 1) Meeting ID를 통해 Meeting 객체 조회
-            Meeting meeting = meetingRepository.findById(userMeeting.getUserMeetingId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
-
-            // 2) 회의 참가자 목록 조회 후, MeetingLogResponse 객체로 반환
-            return getParticipantList(meeting);
+            Meeting meeting = userMeeting.getMeetingId(); // 이미 FETCH된 Meeting 객체 사용
+            return MeetingLogResponse.of(meeting);
         });
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #76 

## 💡 작업내용
- meeting 객체의 참가자 항목으로 조회해 log response 구성
- @Query Join Fetch 방식 도입

## 📝 기타

`/api/v1/meeting/myLog`

- 기존: 7824 ms 소요
- 쿼리 최적화
1. 참가자 항목 meeting에서 가져오기 > 5723 ms
2. @Query Join Fetch 방법 사용 > 3702 ms


`/api/v1/meeting/log`

- 기존: 5862 ms 소요
- 쿼리 최적화
1. 참가자 항목 meeting에서 가져오기 > 3815 ms
2. @Query Join Fetch 방법 사용 >  2300 ms