### PR TITLE
[Fix] Meeting 종료 로직

### DIFF
--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/WebRtcHandler.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/WebRtcHandler.java
@@ -4,6 +4,8 @@ import CloudProject.A_meet.domain.group.domain.meeting.domain.Meeting;
 import CloudProject.A_meet.domain.group.domain.meeting.domain.UserMeeting;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.MeetingRepository;
 import CloudProject.A_meet.domain.group.domain.meeting.repository.UserMeetingRepository;
+import CloudProject.A_meet.domain.group.domain.team.domain.Team;
+import CloudProject.A_meet.domain.group.domain.team.repository.TeamRepository;
 import CloudProject.A_meet.domain.group.domain.user.domain.User;
 import CloudProject.A_meet.domain.group.domain.user.repository.UserRepository;
 import CloudProject.A_meet.domain.group.domain.userTeam.domain.UserTeam;
@@ -41,6 +43,7 @@ public class WebRtcHandler extends TextWebSocketHandler {
     private final UserMeetingRepository userMeetingRepository;
     private final UserRepository userRepository;
     private final MeetingRepository meetingRepository;
+    private final TeamRepository teamRepository;
     private final UserTeamRepository userTeamRepository;
     private final SimpMessagingTemplate messagingTemplate;  // STOMP 메시지 전송
     private final Map<Long, List<String>> meetingParticipants = new HashMap<>();
@@ -69,7 +72,7 @@ public class WebRtcHandler extends TextWebSocketHandler {
 
             Long userId = jsonMessage.get("userId").getAsLong();
             Long meetingId = jsonMessage.get("meetingId").getAsLong();
-            Long userTeamId = jsonMessage.get("userTeamId").getAsLong();
+            Long teamId = jsonMessage.get("teamId").getAsLong();
 
             User user = userRepository.findByUserId(userId)
                     .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -77,7 +80,10 @@ public class WebRtcHandler extends TextWebSocketHandler {
             Meeting meeting = meetingRepository.findByMeetingId(meetingId)
                     .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
 
-            UserTeam userTeam = userTeamRepository.findByUserTeamId(userTeamId)
+            Team team = teamRepository.findByTeamId(teamId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+            UserTeam userTeam = userTeamRepository.findByTeamIdAndUserId(team, user)
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_TEAM_NOT_FOUND));
 
             meeting.addParticipant(user.getNickname());

--- a/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/WebRtcHandler.java
+++ b/src/main/java/CloudProject/A_meet/domain/group/domain/meeting/controller/WebRtcHandler.java
@@ -136,6 +136,16 @@ public class WebRtcHandler extends TextWebSocketHandler {
                 v.remove(userMeeting.getUserId().getNickname());
                 return v.isEmpty() ? null : v;  // 목록이 비면 null로 설정
             });
+
+            if (!meetingParticipants.containsKey(meetingId)) {
+                Meeting meeting = meetingRepository.findByMeetingId(meetingId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
+                meeting.setEndedAt(LocalDateTime.now());
+                meetingRepository.save(meeting);  // 변경 사항 저장
+                logger.info("Meeting {} has been ended as all participants left.", meetingId);
+            }
+
+
             sendParticipantsList(meetingId);
             logger.info("User {} has left the meeting {}", userMeeting.getUserId().getUserId(), userMeeting.getMeetingId().getMeetingId());
         }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #78 

## 💡 작업내용
Meeting 종료 시 회의록 반환 로직 추가
WebRTCHandler meeting API 수정 (Meeting join 및 exit일 때 userId와 teamId만 받기)

## 📸 스크린샷(선택)

## 📝 기타
- meeting마다 다르게 연결하는 거 실패 (급하지 않으니 밥먹고 다시 할게요)
- 자동 녹음 후 미팅이 끝나면 회의록 반환 api는 추후 추가 예정 (WebRTC통신이 되는지 확인 후)